### PR TITLE
feat (prometheus): HTTPS port is configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Installation](#installation)
 - [Tools](#tools)
   - [Prometheus](#prometheus)
+    - [Customize Prometheus](#customize-prometheus)
 
 ## Overview
 
@@ -37,6 +38,10 @@ After installation, make sure to commit the .ddev directory to version control.
 
 Prometheus collects and stores its metrics as time series data, i.e. metrics information is stored with the timestamp at which it was recorded, alongside optional key-value pairs called labels.
 
+To open Prometheus: `ddev prometheus` or `ddev launch :9090` (assuming the default port).
+
+#### Customize Prometheus
+
 Prometheus is configured via `./.ddev/prometheus/prometheus.yml`. This addon provides an example, but need to customize it for your use-case.
 
 To customize, take ownership by removing `#ddev-generated` and making the changes as required.
@@ -51,6 +56,12 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['web'] # Change to your app's hostname and port. Here, we use DDEV web container.
+```
+
+- To customize the default port, update `.ddev/.env`
+
+```config
+PROMETHEUS_HTTPS_PORT=9090
 ```
 
 **Contributed and maintained by [`@tyler36`](https://github.com/tyler36)**

--- a/commands/host/prometheus
+++ b/commands/host/prometheus
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Launch the prometheus website
+## Usage: prometheus
+## Example: "ddev prometheus"
+
+source .ddev/.env
+
+ddev launch :"${PROMETHEUS_HTTPS_PORT:-9090}"

--- a/docker-compose.prometheus.yaml
+++ b/docker-compose.prometheus.yaml
@@ -12,5 +12,4 @@ services:
         com.ddev.approot: $DDEV_APPROOT
       environment:
         - VIRTUAL_HOST=$DDEV_HOSTNAME
-        - HTTP_EXPOSE=9091:9090
-        - HTTPS_EXPOSE=9090:9090
+        - HTTPS_EXPOSE=${PROMETHEUS_HTTPS_PORT:-9090}:9090

--- a/install.yaml
+++ b/install.yaml
@@ -1,8 +1,12 @@
 name: site-metrics
 
 project_files:
-  - docker-compose.prometheus.yaml
+  - commands/host/prometheus
   - prometheus/prometheus.yml
+  - docker-compose.prometheus.yaml
 
 # Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
 ddev_version_constraint: '>= v1.24.3'
+
+post_install_actions:
+  - ddev dotenv set .ddev/.env --prometheus-https-port=9090

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -66,6 +66,23 @@ teardown() {
   health_checks
 }
 
+@test "Prometheus port is configurable" {
+  set -eu -o pipefail
+
+  export PROMETHEUS_HTTPS_PORT=9043
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  ddev dotenv set .ddev/.env --prometheus-https-port="${PROMETHEUS_HTTPS_PORT}"
+  run ddev restart -y
+  assert_success
+
+  run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/query"
+  assert_output --partial "Prometheus Time Series Collection and Processing Server"
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail


### PR DESCRIPTION
## The Issue

The default Prometheus port (9090) might conflict with other services running on the host machine, or users may simply prefer to use a different port for organizational purposes. The current implementation lacks the flexibility to accommodate these scenarios.

## How This PR Solves The Issue

This PR adds a new environment variable PROMETHEUS_HTTPS_PORT to the .ddev/.env file. The default value is set to 9090.

It also adds a ddev prometheus command that will launch the Prometheus UI.

## Manual Testing Instructions

1. Install the addon

```shell
ddev get tyler36/ddev-site-metrics
```

2. Change the port. Edit the `.ddev/.env` file and add or modify the line `PROMETHEUS_HTTPS_PORT=9090`.
3. Restart ddev.
  
```shell
ddev restart
```

4. Verify the port. 
   - Run `ddev launch :9043` and ensure the prometheus UI is available in your browser on the specified port.
   - Run `ddev prometheus` and ensure the prometheus UI is available in your browser on the specified port.

5. Remove the `PROMETHEUS_HTTPS_PORT` line from `.ddev/.env` and run `ddev restart`. Verify that the Prometheus UI is accessible on the default port `9090`.

## Automated Testing Overview

The "Prometheus port is configurable" BATS test confirms the port can be configured.
