### PR TITLE
feat: Add Grafana integration for enhanced metrics visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Tools](#tools)
   - [Prometheus](#prometheus)
     - [Customize Prometheus](#customize-prometheus)
+- [Credits](#credits)
 
 ## Overview
 
@@ -63,5 +64,9 @@ scrape_configs:
 ```config
 PROMETHEUS_HTTPS_PORT=9090
 ```
+
+## Credits
+
+PRs for install steps for specific frameworks are welcome.
 
 **Contributed and maintained by [`@tyler36`](https://github.com/tyler36)**

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 - [Tools](#tools)
   - [Prometheus](#prometheus)
     - [Customize Prometheus](#customize-prometheus)
+  - [Grafana](#grafana)
+    - [Configure Datasources](#configure-datasources)
 - [Credits](#credits)
 
 ## Overview
@@ -19,6 +21,7 @@ This addon contains tools for using [OpenTelemetry](https://github.com/open-tele
 It contains the following packages:
 
 - [Prometheus](https://prometheus.io/docs/introduction/overview/): an open-source systems monitoring and alerting toolkit.
+- [Grafana](https://grafana.com/docs/grafana/latest/): Query, visualize, alert on, and explore your metrics, logs, and traces.
 
 ## Installation
 
@@ -64,6 +67,18 @@ scrape_configs:
 ```config
 PROMETHEUS_HTTPS_PORT=9090
 ```
+
+### Grafana
+
+[Grafana](https://grafana.com/docs/grafana/latest/) is a tool to "Query, visualize, alert on, and explore your metrics, logs, and traces wherever they are stored.".
+
+#### Configure Datasources
+
+This addon pre-configures Prometheus as a datasource.
+
+- To include customize, or include additional datasources, update `.ddev/grafana/datasources/grafana-datasources.yml`.
+
+See [Grafana data sources](https://grafana.com/docs/grafana/latest/datasources/#grafana-data-sources).
 
 ## Credits
 

--- a/commands/host/grafana
+++ b/commands/host/grafana
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Launch the grafana website
+## Usage: grafana
+## Example: "ddev grafana"
+
+source .ddev/.env
+
+ddev launch :"${GRAFANA_HTTPS_PORT:-3000}"

--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -1,0 +1,22 @@
+##ddev-generated
+services:
+    grafana:
+      image: grafana/grafana:latest
+      container_name: ddev-${DDEV_SITENAME}-grafana
+      volumes:
+        - ".:/mnt/ddev_config"
+        - "ddev-global-cache:/mnt/ddev-global-cache"
+      environment:
+        - VIRTUAL_HOST=$DDEV_HOSTNAME
+        - HTTPS_EXPOSE=${GRAFANA_HTTPS_PORT:-3000}:3000
+        # -------------------------
+        # Automatically login as an admin.
+        - GF_AUTH_ANONYMOUS_ENABLED=true
+        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+        - GF_AUTH_DISABLE_LOGIN_FORM=true
+        # ---------------------------
+      labels:
+        com.ddev.site-name: ${DDEV_SITENAME}
+        com.ddev.approot: $DDEV_APPROOT
+      ports:
+        - ${GRAFANA_HTTPS_PORT:-3000}

--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -6,6 +6,7 @@ services:
       volumes:
         - ".:/mnt/ddev_config"
         - "ddev-global-cache:/mnt/ddev-global-cache"
+        - './grafana/datasources:/etc/grafana/provisioning/datasources'
       environment:
         - VIRTUAL_HOST=$DDEV_HOSTNAME
         - HTTPS_EXPOSE=${GRAFANA_HTTPS_PORT:-3000}:3000

--- a/grafana/datasources/grafana-datasources.yml
+++ b/grafana/datasources/grafana-datasources.yml
@@ -1,0 +1,16 @@
+#ddev-generated
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  url: http://prometheus:9090
+  orgId: 1
+  version: 1
+  uid: prometheus
+  access: proxy
+  isDefault: true
+  basicAuth: false
+  editable: false
+  jsonData:
+    httpMethod: GET

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: site-metrics
 
 project_files:
   - commands/host/prometheus
+  - grafana/datasources/grafana-datasources.yml
   - prometheus/prometheus.yml
   - commands/host/grafana
   - docker-compose.prometheus.yaml

--- a/install.yaml
+++ b/install.yaml
@@ -3,10 +3,13 @@ name: site-metrics
 project_files:
   - commands/host/prometheus
   - prometheus/prometheus.yml
+  - commands/host/grafana
   - docker-compose.prometheus.yaml
+  - docker-compose.grafana.yaml
 
 # Available with DDEV v1.23.4+, and works only for DDEV v1.23.4+ binaries
 ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
   - ddev dotenv set .ddev/.env --prometheus-https-port=9090
+  - ddev dotenv set .ddev/.env --grafana-https-port=3000

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -106,6 +106,21 @@ teardown() {
   assert_output --partial "Grafana"
 }
 
+@test "Grafana is pre-configured with Prometheus datasource" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  # Grafana uses the HTTP endpoint, so check that the datasources contains the correct URL.
+  run ddev exec -s grafana cat /etc/grafana/provisioning/datasources/grafana-datasources.yml
+  assert_output --partial 'url: http://prometheus:9090'
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -40,11 +40,17 @@ setup() {
 
 health_checks() {
   prometheus_health_check
+  grafana_health_check
 }
 
 prometheus_health_check() {
   run curl -sf "https://${PROJNAME}.ddev.site:9090/query"
   assert_output --partial "Prometheus Time Series Collection and Processing Server"
+}
+
+grafana_health_check() {
+  run curl -sf "https://${PROJNAME}.ddev.site:3000"
+  assert_output --partial "<title>Grafana</title>"
 }
 
 teardown() {
@@ -81,6 +87,23 @@ teardown() {
 
   run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/query"
   assert_output --partial "Prometheus Time Series Collection and Processing Server"
+}
+
+@test "Grafana port is configurable" {
+  set -eu -o pipefail
+
+  export GRAFANA_HTTPS_PORT=3043
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  ddev dotenv set .ddev/.env --grafana-https-port="${GRAFANA_HTTPS_PORT}"
+  run ddev restart -y
+  assert_success
+
+  run curl -sf "https://${PROJNAME}.ddev.site:${GRAFANA_HTTPS_PORT}"
+  assert_output --partial "Grafana"
 }
 
 # bats test_tags=release


### PR DESCRIPTION
## The Issue

Currently, the `site-metrics` add-on provides Prometheus for collecting metrics, but lacks a user-friendly interface for visualizing and exploring this data. This limits the usability of the collected metrics for monitoring and analysis.

## How This PR Solves The Issue

This pull request adds Grafana as an additional service to the add-on. Grafana is pre-configured with Prometheus as a datasource, allowing users to immediately start visualizing their metrics. This provides a comprehensive solution for collecting, storing, and visualizing site metrics within the ddev environment.

## Manual Testing Instructions

1.  Install the add-on:

    ```bash
    ddev get tyler36/ddev-site-metrics
    ddev restart
    ```

2.  Access Grafana:

    *   Run `ddev grafana`. This will open the Grafana web interface in your browser. It should automatically log you in as an admin.
    *   Alternatively, access Grafana directly using the URL `https://<ddev-site-name>.ddev.site:3000` (or the port configured in `.ddev/.env`).

3.  Verify Prometheus datasource:

    *   In Grafana, navigate to `/connections/datasources` and verify that Prometheus is listed as a datasource with the name "Prometheus".



## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

*   The Grafana service uses the `GRAFANA_HTTPS_PORT` variable from the `.ddev/.env` file.  The default is 3000.
*   Grafana automatically logs in as an admin user without requiring login.
