### PR TITLE
Fix: Grafana Data Loss on `ddev stop`

### DIFF
--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -6,9 +6,10 @@ services:
     volumes:
       - '.:/mnt/ddev_config'
       - 'ddev-global-cache:/mnt/ddev-global-cache'
-      - 'grafana-storage:/var/lib/grafana'
       - './grafana/datasources:/etc/grafana/provisioning/datasources'
       - './grafana/dashboards:/etc/grafana/provisioning/dashboards'
+      ## Disable the following line to prevent Grafana saving data between restarts.
+      - 'grafana-storage:/var/lib/grafana'
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTPS_EXPOSE=${GRAFANA_HTTPS_PORT:-3000}:3000

--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -1,22 +1,28 @@
 ##ddev-generated
 services:
-    grafana:
-      image: grafana/grafana:latest
-      container_name: ddev-${DDEV_SITENAME}-grafana
-      volumes:
-        - ".:/mnt/ddev_config"
-        - "ddev-global-cache:/mnt/ddev-global-cache"
-        - './grafana/datasources:/etc/grafana/provisioning/datasources'
-        - './grafana/dashboards:/etc/grafana/provisioning/dashboards'
-      environment:
-        - VIRTUAL_HOST=$DDEV_HOSTNAME
-        - HTTPS_EXPOSE=${GRAFANA_HTTPS_PORT:-3000}:3000
-        # -------------------------
-        # Automatically login as an admin.
-        - GF_AUTH_ANONYMOUS_ENABLED=true
-        - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-        - GF_AUTH_DISABLE_LOGIN_FORM=true
-        # ---------------------------
-      labels:
-        com.ddev.site-name: ${DDEV_SITENAME}
-        com.ddev.approot: $DDEV_APPROOT
+  grafana:
+    image: grafana/grafana:latest
+    container_name: ddev-${DDEV_SITENAME}-grafana
+    volumes:
+      - '.:/mnt/ddev_config'
+      - 'ddev-global-cache:/mnt/ddev-global-cache'
+      - 'grafana-storage:/var/lib/grafana'
+      - './grafana/datasources:/etc/grafana/provisioning/datasources'
+      - './grafana/dashboards:/etc/grafana/provisioning/dashboards'
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=${GRAFANA_HTTPS_PORT:-3000}:3000
+      # -------------------------
+      # Automatically login as an admin.
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      # ---------------------------
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    ports:
+      - ${GRAFANA_HTTPS_PORT:-3000}
+
+volumes:
+  grafana-storage:

--- a/install.yaml
+++ b/install.yaml
@@ -47,6 +47,7 @@ project_files:
 ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
+  - docker volume create grafana-storage
   - ddev dotenv set .ddev/.env --prometheus-https-port=9090 > /dev/null 2>&1
   - ddev dotenv set .ddev/.env --grafana-https-port=3000 > /dev/null 2>&1
   - |


### PR DESCRIPTION
## The Issue

Grafana data (dashboards, configurations, etc.) was lost whenever the `ddev stop` command was executed. This occurred because the Grafana container's data directory (`/var/lib/grafana`) wasn't persisted in a Docker volume.  Stopping the container without a persistent volume would effectively remove the data stored within the container's filesystem.

## How This PR Solves The Issue

This pull request addresses the data loss issue by:

1.  **Creating a Docker volume:** Defines a Docker volume named `grafana-storage` in `docker-compose.grafana.yaml` and mounts it to `/var/lib/grafana` within the Grafana container. This ensures that Grafana's data is stored outside of the container's lifecycle.  We ensure that this volume is created when the addon is installed using `docker volume create grafana-storage` in `install.yaml`.
2.  **Making the volume external:** Declare the volume as `external: true` in the `docker-compose.grafana.yaml` file so that `ddev` will not attempt to manage its lifecycle.

## Manual Testing Instructions

1.  **Install the Addon:** `ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/persis-grafana-data`
2.  **Start the project:** `ddev start`
3.  **Access Grafana:** Open Grafana in your browser using the URL displayed by `ddev describe` (likely something like `https://<project_name>.ddev.site:3000`) and log in with the default credentials (admin/admin).
4.  **Create a Dashboard:**  Create a simple dashboard in Grafana (e.g., add a text panel or connect to a dummy data source).
5.  **Stop the Project:** `ddev stop`
6.  **Start the Project Again:** `ddev start`
7.  **Verify Data Persistence:**  Access Grafana again. The dashboard you created in step 4 should still be present.  If the dashboard is present, the data has been successfully persisted.

This fix ensures that Grafana data is preserved across `ddev stop` and `ddev start` cycles, providing a more reliable and user-friendly experience.


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
