### PR TITLE
refactor: hide ENV setup

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -19,5 +19,5 @@ project_files:
 ddev_version_constraint: '>= v1.24.3'
 
 post_install_actions:
-  - ddev dotenv set .ddev/.env --prometheus-https-port=9090
-  - ddev dotenv set .ddev/.env --grafana-https-port=3000
+  - ddev dotenv set .ddev/.env --prometheus-https-port=9090 > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env --grafana-https-port=3000 > /dev/null 2>&1


### PR DESCRIPTION
## The Issue

When installing the addon the following warnings are displayed:

```
Updated /home/user47/prometheus-graphana-l11-demo/.ddev/.env with:

PROMETHEUS_HTTPS_PORT="9090"
 
Updated /home/user47/prometheus-graphana-l11-demo/.ddev/.env with:

GRAFANA_HTTPS_PORT="3000"
```

They aren't really warnings, but the orange color stands out as such.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR hides the output when setting the Prometheus and Grafana ENV ports.

## Manual Testing Instructions


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
