### PR TITLE
fix: take ownership of default dashboards

### DIFF
--- a/grafana/dashboards/mysql.json
+++ b/grafana/dashboards/mysql.json
@@ -1,4 +1,5 @@
 {
+  "help": "##ddev-generated",
   "annotations": {
     "list": [
       {

--- a/grafana/dashboards/nginx.json
+++ b/grafana/dashboards/nginx.json
@@ -1,4 +1,5 @@
 {
+  "help": "##ddev-generated",
   "annotations": {
     "list": [
       {


### PR DESCRIPTION
## The Issue

Current default dashboards lack DDEV signature and are therefore not updated when updating app.

## How This PR Solves The Issue

This PRs adds the DDEV signature that allows the addon to manage the files.

Remove the signature to take ownership of a dashboard and therefore persist changes.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/take-ownership-of-default-dashboards
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
