### PR TITLE
fix: cleanup port assignment

### DIFF
--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -20,5 +20,3 @@ services:
       labels:
         com.ddev.site-name: ${DDEV_SITENAME}
         com.ddev.approot: $DDEV_APPROOT
-      ports:
-        - ${GRAFANA_HTTPS_PORT:-3000}

--- a/docker-compose.mysqld-exporter.yaml
+++ b/docker-compose.mysqld-exporter.yaml
@@ -13,5 +13,5 @@ services:
     - "./mysqld_exporter/.my.cnf:/opt/mysqld_exporter/.my.cnf"
     command:
     - "--config.my-cnf=/opt/mysqld_exporter/.my.cnf"
-    ports:
-    - 9104:9104
+    environment:
+      - HTTP_EXPOSE=9104:9104


### PR DESCRIPTION
## The Issue

The current implementation exposes ports when they are not needed. This can cause conflicts if another project is also running the ddev-site-metrics.

## How This PR Solves The Issue

This PR exposes ports inside docker only, thus limiting them to the single project and avoiding conflicts.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix-port-conflicts
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
