### PR TITLE
fix: nginx target in prometheus config

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -4,6 +4,8 @@ global:
 scrape_configs:
   - job_name: 'nginx'
     metrics_path: '/metrics'
+    static_configs:
+      - targets: ['nginx-prometheus-exporter:9113'] 
   - job_name: mysql # To get metrics about the mysql exporter's targets
     metrics_path: /probe
     params:


### PR DESCRIPTION
## The Issue

The static config for nginx-prometheus-exported shows "No targets" in Promoteus.
It was managed in a previous merge conflict resolution.

## How This PR Solves The Issue

Restore static config for 'nginx-prometheus-exporter'.

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix-nginx-target
ddev restart
```

2. View Prometheus and confirm nginx has valid target.

```bash
ddev prometheus
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
