### PR TITLE
feat: Add Loki and Alloy for centralized logging

### DIFF
--- a/alloy/alloy-logs.alloy
+++ b/alloy/alloy-logs.alloy
@@ -1,0 +1,27 @@
+// ##ddev-generated
+
+/**
+ * 'logging' is an optional configuration block used to customize how Alloy produces log messages.
+ * @See https://grafana.com/docs/alloy/latest/reference/config-blocks/logging/
+ */
+logging {
+  level  = "debug"
+  format = "logfmt"
+  write_to = [loki.process.alloy.receiver]
+}
+
+/**
+ * 'loki.process' receives log entries from other loki components, applies one or more processing stages,
+ * and forwards the results to the list of receivers in the component’s arguments.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/
+ *
+ * 'loki.write.default.receiver' is defined in `alloy/ddev-loki.alloy`
+ */
+loki.process "alloy" {
+  stage.labels {
+    values = {
+      service_name = "alloy",
+    }
+  }
+  forward_to = [loki.write.default.receiver]
+}

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,6 +1,48 @@
-##ddev-generated
+// ##ddev-generated
+// This component is responsible for discovering new containers within the docker environment
+discovery.docker "docker" {
+  host = "unix:///var/run/docker.sock"
+  refresh_interval = "5s"
+}
 
-logging {
-  level  = "info"
-  format = "logfmt"
+// This component is responsible for relabeling the discovered containers
+discovery.relabel "docker" {
+  targets = []
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+}
+
+// This component is responsible for collecting logs from the discovered containers
+loki.source.docker "docker" {
+  host             = "unix:///var/run/docker.sock"
+  targets          = discovery.docker.docker.targets
+  forward_to       = [loki.process.docker.receiver]
+  relabel_rules    = discovery.relabel.docker.rules
+  refresh_interval = "5s"
+}
+
+// This component is responsible for processing the logs (In this case adding static labels)
+loki.process "docker" {
+    stage.static_labels {
+    values = {
+        env = "production",
+      }
+    }
+    forward_to = [loki.write.docker.receiver]
+}
+
+// This component is responsible for writing the logs to Loki
+loki.write "docker" {
+  endpoint {
+    url  = "http://loki:3100/loki/api/v1/push"
+  }
+}
+
+// Enables the ability to view logs in the Alloy UI in realtime
+livedebugging {
+  enabled = true
 }

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,6 @@
+##ddev-generated
+
+logging {
+  level  = "info"
+  format = "logfmt"
+}

--- a/alloy/configurations.md
+++ b/alloy/configurations.md
@@ -5,6 +5,8 @@ This directory is contains Alloy configuration files.
 
 Alloy finds `*.alloy` files (ignoring nested directories) and loads them as a single configuration source. However, component names must be unique across all Alloy configuration files, and configuration blocks must not be repeated.
 
+See [Components](https://grafana.com/docs/alloy/latest/reference/components/).
+
 To send content to DDEV's Loki implementation, forward content to `loki.write.default.receiver`
 
 ```yaml

--- a/alloy/configurations.md
+++ b/alloy/configurations.md
@@ -1,0 +1,14 @@
+# Configuration
+<!-- ##ddev-generated -->
+
+This directory is contains Alloy configuration files.
+
+Alloy finds `*.alloy` files (ignoring nested directories) and loads them as a single configuration source. However, component names must be unique across all Alloy configuration files, and configuration blocks must not be repeated.
+
+To send content to DDEV's Loki implementation, forward content to `loki.write.default.receiver`
+
+```yaml
+  forward_to = [loki.write.default.receiver]
+```
+
+- To disable a configuration, rename the extension to `.example`.

--- a/alloy/ddev-loki.alloy
+++ b/alloy/ddev-loki.alloy
@@ -1,0 +1,10 @@
+// ##ddev-generated
+/**
+ * This component is responsible for writing the logs to Loki.
+ * We have centralized it here so other components can reference it.
+ */
+loki.write "default" {
+  endpoint {
+    url  = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/alloy/ddev-loki.alloy
+++ b/alloy/ddev-loki.alloy
@@ -1,7 +1,8 @@
 // ##ddev-generated
 /**
- * This component is responsible for writing the logs to Loki.
+ * 'loki.write receives' log entries from other loki components and sends them over the network using the Loki logproto format.
  * We have centralized it here so other components can reference it.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.write/
  */
 loki.write "default" {
   endpoint {

--- a/alloy/docker.alloy
+++ b/alloy/docker.alloy
@@ -27,22 +27,10 @@ loki.source.docker "docker" {
 
 // This component is responsible for processing the logs (In this case adding static labels)
 loki.process "docker" {
-    stage.static_labels {
+  stage.static_labels {
     values = {
         env = "production",
       }
-    }
-    forward_to = [loki.write.docker.receiver]
-}
-
-// This component is responsible for writing the logs to Loki
-loki.write "docker" {
-  endpoint {
-    url  = "http://loki:3100/loki/api/v1/push"
   }
-}
-
-// Enables the ability to view logs in the Alloy UI in realtime
-livedebugging {
-  enabled = true
+  forward_to = [loki.write.default.receiver]
 }

--- a/alloy/docker.alloy
+++ b/alloy/docker.alloy
@@ -1,11 +1,18 @@
 // ##ddev-generated
-// This component is responsible for discovering new containers within the docker environment
+/**
+ * 'discovery.docker' discovers Docker Engine containers and exposes them as targets.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.docker/
+ */
 discovery.docker "docker" {
   host = "unix:///var/run/docker.sock"
   refresh_interval = "5s"
 }
 
-// This component is responsible for relabeling the discovered containers
+/**
+ * 'discovery.relabel' rewrites the label set of the input targets by applying one or more relabeling rules.
+ * If no rules are defined, then the input targets are exported as-is.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/
+ */
 discovery.relabel "docker" {
   targets = []
 
@@ -16,7 +23,10 @@ discovery.relabel "docker" {
   }
 }
 
-// This component is responsible for collecting logs from the discovered containers
+/**
+ * 'loki.source.docker' reads log entries from Docker containers and forwards them to other loki.* components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.docker/
+ */
 loki.source.docker "docker" {
   host             = "unix:///var/run/docker.sock"
   targets          = discovery.docker.docker.targets
@@ -25,7 +35,13 @@ loki.source.docker "docker" {
   refresh_interval = "5s"
 }
 
-// This component is responsible for processing the logs (In this case adding static labels)
+/**
+ * 'loki.process' receives log entries from other loki components, applies one or more processing stages,
+ * and forwards the results to the list of receivers in the component’s arguments.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/
+ *
+ * 'loki.write.default.receiver' is defined in `alloy/ddev-loki.alloy`
+ */
 loki.process "docker" {
   stage.static_labels {
     values = {

--- a/alloy/livedebugging.alloy
+++ b/alloy/livedebugging.alloy
@@ -1,0 +1,8 @@
+// ##ddev-generated
+/**
+ * Enables the ability to view logs in the Alloy UI in realtime.
+ * The server must be run with: "--server.http.listen-addr=0.0.0.0:12345"
+ */
+livedebugging {
+  enabled = true
+}

--- a/commands/host/alloy
+++ b/commands/host/alloy
@@ -1,10 +1,28 @@
 #!/usr/bin/env bash
 
 #ddev-generated
-## Description: Launch the alloy website
+## Description: Helper function for Alloy
 ## Usage: alloy
-## Example: "ddev alloy"
+## Example: "ddev alloy", "ddev alloy --reload"
 
-source .ddev/.env
+# Open Alloy in preferred browser.
+launch () {
+  ddev launch :12345
+}
 
-ddev launch :12345
+# Send a request to reload configuration.
+reloadConfig() {
+  curl -X POST "${DDEV_PRIMARY_URL}:12345/-/reload"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -r | --reload)
+    reloadConfig
+    exit 0;
+    ;;
+  esac
+  shift
+done
+
+launch

--- a/commands/host/alloy
+++ b/commands/host/alloy
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+#ddev-generated
+## Description: Launch the alloy website
+## Usage: alloy
+## Example: "ddev alloy"
+
+source .ddev/.env
+
+ddev launch :12345

--- a/docker-compose.alloy.yaml
+++ b/docker-compose.alloy.yaml
@@ -12,8 +12,8 @@ services:
     volumes:
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
-      - ./alloy/config.alloy:/etc/alloy/config.alloy
+      - ./alloy:/etc/alloy
       - /var/run/docker.sock:/var/run/docker.sock
-    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy
     depends_on:
       - loki

--- a/docker-compose.alloy.yaml
+++ b/docker-compose.alloy.yaml
@@ -1,0 +1,15 @@
+##ddev-generated
+services:
+  alloy:
+    container_name: ddev-${DDEV_SITENAME}-alloy
+    image: grafana/alloy:latest
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    volumes:
+      - '.:/mnt/ddev_config'
+      - 'ddev-global-cache:/mnt/ddev-global-cache'
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=${ALLOY_HTTPS_PORT:-12345}:12345
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy

--- a/docker-compose.alloy.yaml
+++ b/docker-compose.alloy.yaml
@@ -10,6 +10,8 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTPS_EXPOSE=12345:12345
     volumes:
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"
       - ./alloy/config.alloy:/etc/alloy/config.alloy
       - /var/run/docker.sock:/var/run/docker.sock
     command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy

--- a/docker-compose.alloy.yaml
+++ b/docker-compose.alloy.yaml
@@ -2,14 +2,16 @@
 services:
   alloy:
     container_name: ddev-${DDEV_SITENAME}-alloy
-    image: grafana/alloy:latest
+    image: grafana/alloy:v1.7.5
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
-    volumes:
-      - '.:/mnt/ddev_config'
-      - 'ddev-global-cache:/mnt/ddev-global-cache'
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTPS_EXPOSE=${ALLOY_HTTPS_PORT:-12345}:12345
+      - HTTPS_EXPOSE=12345:12345
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
     command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki

--- a/docker-compose.loki.yaml
+++ b/docker-compose.loki.yaml
@@ -1,0 +1,15 @@
+##ddev-generated
+services:
+  loki:
+    container_name: ddev-${DDEV_SITENAME}-loki
+    image: grafana/loki:latest
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    volumes:
+    - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
+    command: -config.file=/etc/loki/local-config.yaml
+    environment:
+      - HTTP_EXPOSE=3100:3100

--- a/docker-compose.loki.yaml
+++ b/docker-compose.loki.yaml
@@ -2,7 +2,7 @@
 services:
   loki:
     container_name: ddev-${DDEV_SITENAME}-loki
-    image: grafana/loki:latest
+    image: grafana/loki:3.4.2
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -10,6 +10,8 @@ services:
     volumes:
     - ".:/mnt/ddev_config"
     - "ddev-global-cache:/mnt/ddev-global-cache"
+    - ./loki/local-config.yaml:/etc/loki/local-config.yaml
     command: -config.file=/etc/loki/local-config.yaml
     environment:
-      - HTTP_EXPOSE=3100:3100
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=3100:3100

--- a/grafana/datasources/ddev-loki.yml
+++ b/grafana/datasources/ddev-loki.yml
@@ -1,0 +1,13 @@
+##ddev-generated
+apiVersion: 1
+
+datasources:
+- name: Loki
+  type: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false

--- a/install.yaml
+++ b/install.yaml
@@ -10,6 +10,9 @@ project_files:
   - commands/host/grafana
   - docker-compose.prometheus.yaml
   - docker-compose.grafana.yaml
+  # The following files belong to the loki/alloy feature
+  - docker-compose.loki.yaml
+  - grafana/datasources/ddev-loki.yml
   # The following files belong to the nginx-prometheus-exporter feature.
   - docker-compose.nginx-prometheus-exporter.yaml
   - nginx_full/stub_status.conf

--- a/install.yaml
+++ b/install.yaml
@@ -13,6 +13,7 @@ project_files:
   # The following files belong to the loki/alloy feature
   - docker-compose.loki.yaml
   - grafana/datasources/ddev-loki.yml
+  - loki/local-config.yaml
   - docker-compose.alloy.yaml
   - alloy
   - commands/host/alloy

--- a/install.yaml
+++ b/install.yaml
@@ -13,6 +13,9 @@ project_files:
   # The following files belong to the loki/alloy feature
   - docker-compose.loki.yaml
   - grafana/datasources/ddev-loki.yml
+  - docker-compose.alloy.yaml
+  - alloy
+  - commands/host/alloy
   # The following files belong to the nginx-prometheus-exporter feature.
   - docker-compose.nginx-prometheus-exporter.yaml
   - nginx_full/stub_status.conf

--- a/loki/local-config.yaml
+++ b/loki/local-config.yaml
@@ -1,0 +1,64 @@
+##ddev-generated
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  metric_aggregation_enabled: true
+  allow_structured_metadata: true
+  volume_enabled: true
+  retention_period: 24h   # 24h
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+ruler:
+  enable_alertmanager_discovery: true
+  enable_api: true
+
+
+
+
+frontend:
+  encoding: protobuf
+
+
+compactor:
+  working_directory: /tmp/loki/retention
+  delete_request_store: filesystem
+  retention_enabled: true

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -41,6 +41,7 @@ setup() {
 health_checks() {
   prometheus_health_check
   grafana_health_check
+  loki_health_check
 }
 
 prometheus_health_check() {
@@ -51,6 +52,11 @@ prometheus_health_check() {
 grafana_health_check() {
   run curl -sf "https://${PROJNAME}.ddev.site:3000"
   assert_output --partial "<title>Grafana</title>"
+}
+
+loki_health_check() {
+  run ddev exec curl -sf "loki:3100/metrics"
+  assert_output --partial "HELP loki_dns_lookups_total The number of DNS lookups resolutions attempts"
 }
 
 teardown() {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -62,7 +62,7 @@ loki_health_check() {
 
 alloy_health_check() {
   # Attempt to reload alloy configuration to prove the site is functioning.
-  run curl -X POST https://${PROJNAME}.ddev.site:12345/-/reload
+  run ddev alloy -r
   assert_output --partial config reloaded
 }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -42,6 +42,7 @@ health_checks() {
   prometheus_health_check
   grafana_health_check
   loki_health_check
+  alloy_health_check
 }
 
 prometheus_health_check() {
@@ -57,6 +58,12 @@ grafana_health_check() {
 loki_health_check() {
   run ddev exec curl -sf "loki:3100/metrics"
   assert_output --partial "HELP loki_dns_lookups_total The number of DNS lookups resolutions attempts"
+}
+
+alloy_health_check() {
+  # Attempt to reload alloy configuration to prove the site is functioning.
+  run curl -X POST https://${PROJNAME}.ddev.site:12345/-/reload
+  assert_output --partial config reloaded
 }
 
 teardown() {


### PR DESCRIPTION
## The Issue

Currently, DDEV lacks a centralized logging solution. Developers need to access logs from individual containers, which can be cumbersome and time-consuming, especially in complex projects.

## How This PR Solves The Issue

This pull request adds Loki, a log aggregation system, and Alloy, a configuration-as-code observability framework from Grafana Labs, to DDEV. This allows DDEV to collect, process, and store logs from all containers in a project.

*   Centralized logging: All project logs are aggregated in one place.
*   Improved debugging: Easier to identify and diagnose issues.
*   Enhanced monitoring: Provides insights into application behavior.

## Manual Testing Instructions

1. Install addon in an existing project

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/loki
ddev restart
```

2. Open Grafana dashboard

```bash
ddev grafana
```

3. Visit `Drilldown | Logs` (/a/grafana-lokiexplore-app/explore) and verify that:

- Docker logs for active contains are vieable
- alloy service logs are viewable

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
