### PR TITLE
feat (prometheus): add Alloy metrics

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -2,10 +2,15 @@ global:
   scrape_interval: 5s  # How often Prometheus scrapes data
 
 scrape_configs:
+  # Add Loki metrics
+  - job_name: 'loki'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['loki:3100']
   - job_name: 'nginx'
     metrics_path: '/metrics'
     static_configs:
-      - targets: ['nginx-prometheus-exporter:9113'] 
+      - targets: ['nginx-prometheus-exporter:9113']
   - job_name: mysql # To get metrics about the mysql exporter's targets
     metrics_path: /probe
     params:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -2,6 +2,11 @@ global:
   scrape_interval: 5s  # How often Prometheus scrapes data
 
 scrape_configs:
+  # Add Alloy metrics
+  - job_name: 'alloy'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['alloy:12345']
   # Add Loki metrics
   - job_name: 'loki'
     metrics_path: '/metrics'


### PR DESCRIPTION
## The Issue

Both Alloy and Loki expose metrics that can be consumed by Prometheus.

## How This PR Solves The Issue

This PR configures Prometheus to scape the metrics enpoints for:

- Alloy
- Loki

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/expose-logging-metrics
ddev restart
```

2. Visit `:3000/explore/metrics` 
3. Confirm when Data source is set to Prometheus, 

- "View by" set to `alloy_` displays metrics
- "View by" set to `loki_` displays metrics

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
