### PR TITLE
fix: Add tags for Nginx dashboard in Grafana

### DIFF
--- a/grafana/dashboards/nginx.json
+++ b/grafana/dashboards/nginx.json
@@ -513,7 +513,11 @@
   ],
   "preload": false,
   "schemaVersion": 41,
-  "tags": [],
+  "tags": [
+    "web",
+    "nginx",
+    "prometheus"
+  ],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
## The Issue

The included Nginx dashboard is missing tags.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR adds tags, in line with the other included dashboards.

## Manual Testing Instructions

1. Install dashboarfd.

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/tag-nginx-dashboard
ddev restart
```

2. Check Nginx dashboard contains relevant tags.

```shell
ddev launch :3000/dashboards
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
