### PR TITLE
chore: bump Alloy version

### DIFF
--- a/docker-compose.alloy.yaml
+++ b/docker-compose.alloy.yaml
@@ -2,7 +2,7 @@
 services:
   alloy:
     container_name: ddev-${DDEV_SITENAME}-alloy
-    image: grafana/alloy:v1.7.5
+    image: grafana/alloy:v1.8.3
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}


### PR DESCRIPTION
## The Issue

The UI for Alloy has changed in the last couple of minor versions. This makes following newer tutorials more difficult.

## How This PR Solves The Issue

Bump Grafana Alloy version.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/bump-alloy
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
