### PR TITLE
fix: automated tests

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -185,7 +185,7 @@ teardown() {
 
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs nginx-prometheus-exporter:9113/metrics
-  assert_output --partial 'HELP nginx_connections_accepted Accepted client connections'
+  assert_output --partial 'HELP nginx_exporter_build_info'
 }
 
 @test "MYSQLD-exporter exposes statistics" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -180,7 +180,7 @@ teardown() {
   assert_success
 
   # Check it exposes scraping URI
-  run ddev exec curl -vs http://web:8080/stub_status
+  run ddev exec curl -vs http://127.0.0.1:8080/stub_status
   assert_output --partial 'server accepts handled request'
 
   # Check it exposes endpoint with statistics


### PR DESCRIPTION
## The Issue

The 'Nginx-prometheus-exporter exposes statistics' passes locally but fails in GitHub. 

The issue causes scheduled tests to fails so it should be fixed or worked around.

## How This PR Solves The Issue

This PR explores solutions to rolsve pipeline. Merge once tests pass.

## Manual Testing Instructions

1. Download project

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/ddev-site-matric-fix-test
ddev restart
```

1. Run test

```shell
bats ./tests/test.bats -f 'Nginx-prometheus-exporter exposes statistics'
```

1. Check GitHub workflow is passing at https://github.com/tyler36/ddev-site-metrics/actions


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
