### PR TITLE
fix: take ownership of config file

### DIFF
--- a/tempo/tempo-config.yaml
+++ b/tempo/tempo-config.yaml
@@ -1,3 +1,4 @@
+##ddev-generated
 server:
   http_listen_port: 3200
   grpc_listen_port: 3300


### PR DESCRIPTION
## The Issue

`tempo-config.yaml` is missing DDEV signature. This prevents newer versions of the addon from overriding its contents.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

Add signature.

## Manual Testing Instructions

1. Install addon.

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics
ddev restart
```

1. Install addon again. You should NOT see warning about "NOT overwriting ... tempo/tempo-config.yaml" .

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
