### PR TITLE
refactor: Grafana implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@
 - [Overview](#overview)
 - [Installation](#installation)
 - [Tools](#tools)
-  - [Prometheus](#prometheus)
-    - [Customize Prometheus](#customize-prometheus)
-    - [Addon: nginx-prometheus-exporter](#addon-nginx-prometheus-exporter)
-    - [Addon: MySql Exporter](#addon-mysql-exporter)
-    - [Addon: postgres-exporter](#addon-postgres-exporter)
-    - [Addon: node-exporter](#addon-node-exporter)
   - [Grafana](#grafana)
     - [Configure Datasources](#configure-datasources)
     - [Configure Dashboards](#configure-dashboards)
@@ -22,6 +16,12 @@
       - [Usage](#usage)
     - [Grafana Loki](#grafana-loki)
     - [Grafana Tempo](#grafana-tempo)
+  - [Prometheus](#prometheus)
+    - [Customize Prometheus](#customize-prometheus)
+    - [Addon: nginx-prometheus-exporter](#addon-nginx-prometheus-exporter)
+    - [Addon: MySql Exporter](#addon-mysql-exporter)
+    - [Addon: postgres-exporter](#addon-postgres-exporter)
+    - [Addon: node-exporter](#addon-node-exporter)
 - [Credits](#credits)
 
 ## Overview
@@ -45,6 +45,101 @@ ddev restart
 After installation, make sure to commit the .ddev directory to version control.
 
 ## Tools
+
+### Grafana
+
+[Grafana](https://grafana.com/docs/grafana/latest/) is a tool to "Query, visualize, alert on, and explore your metrics, logs, and traces wherever they are stored.".
+
+#### Configure Datasources
+
+This addon pre-configures Prometheus as a datasource.
+
+- To include customize, or include additional datasources, update `.ddev/grafana/datasources/grafana-datasources.yml`.
+
+See [Grafana data sources](https://grafana.com/docs/grafana/latest/datasources/#grafana-data-sources).
+
+#### Configure Dashboards
+
+This add-on pre-configures `.ddev/grafana/dashboards` as the provisioned dashboard folder.
+See [Dashboards](https://grafana.com/docs/grafana/latest/dashboards/).
+See [Dashboard JSON model](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/).
+
+#### Configure plugins
+
+To install a plugin, create or update `.ddev/docker-compose.grafana_custom.yaml`.
+Replace `<plugin-id>` with the plugin ID.
+
+```yaml
+services:
+  grafana:
+    environment:
+      - GF_PLUGINS_PREINSTALL=<plugin-id>
+```
+
+To find the plugin ID:
+
+- visit [All plugins for Grafana](https://grafana.com/grafana/plugins/all-plugins/).
+- search for the desired plugin.
+- click the "Installation" tab.
+- Look at the "Install the Panel" code. In the below example, `grafana-clock-panel` is the plugin ID.
+
+    ```shell
+    grafana-cli plugins install grafana-clock-panel
+    ```
+
+#### Grafana Alloy
+
+[Grafana Alloy](https://grafana.com/docs/alloy/latest/) can collect, process, and export telemetry signals to scale and future-proof your observability approach.
+
+This addon configures Grafana Alloy to collect and process:
+
+- Docker logs (`alloy/docker.alloy`),
+- Alloy logs (`alloy/alloy-logs.alloy`)
+- Enable live debugging of Alloy pipelines, where supported
+- Adds a pipeline to a DDEV-supported Grafana Loki process
+
+To configure Alloy, add/update files in `.ddev/alloy`. By default, all files in this directory are loaded and processed.
+
+##### Usage
+
+Grafana Alloy runs within the process on its default port of `12345`.
+
+- To open the Grafana Alloy dashboard, run the following command:
+
+```shell
+ddev alloy
+```
+
+- To reload Alloy configuration, run the following command:
+
+```shell
+ddev alloy -r
+```
+
+#### Grafana Loki
+
+[Grafana Loki](https://grafana.com/docs/loki/latest/) is a set of open source components that can be composed into a fully featured logging stack.
+
+Grafana Loki listens on its default port of `3100`.
+To view processed logs, visit `Drilldown | Logs` in the Grafana dashboard.
+
+```shell
+ddev :3000/a/grafana-lokiexplore-app/explore
+```
+
+#### Grafana Tempo
+
+[Grafana Tempo](https://grafana.com/docs/tempo/latest/) is an open-source, easy-to-use, and high-scale distributed tracing backend.
+
+In this add-on, Grafana Alloy forwards open telemetry data it receives to Grafana Tempo for processing ([./alloy/otelcol.alloy](./alloy/otelcol.alloy)). Grafana Tempo datasource is pre-configured in Grafana allowing a centralized location for interacting with traces.
+
+- To configure Grafana Tempo, update `.ddev/tempo/tempo-config.yaml` and restart DDEV.
+- To forward Grafana Tempo traces to Grafana, update `.ddev/.env.tempo`
+
+```conf
+OTEL_SERVICE_NAME="tempo"
+OTEL_EXPORTER_OTLP_ENDPOINT="http://alloy:4318"
+```
 
 ### Prometheus
 
@@ -158,101 +253,6 @@ To change the port,
 - restart DDEV to apply the changes.
 
 This addon includes an example node dashboard based on [Node Exporter Full (v40)](https://grafana.com/grafana/dashboards/1860-node-exporter-full/).
-
-### Grafana
-
-[Grafana](https://grafana.com/docs/grafana/latest/) is a tool to "Query, visualize, alert on, and explore your metrics, logs, and traces wherever they are stored.".
-
-#### Configure Datasources
-
-This addon pre-configures Prometheus as a datasource.
-
-- To include customize, or include additional datasources, update `.ddev/grafana/datasources/grafana-datasources.yml`.
-
-See [Grafana data sources](https://grafana.com/docs/grafana/latest/datasources/#grafana-data-sources).
-
-#### Configure Dashboards
-
-This add-on pre-configures `.ddev/grafana/dashboards` as the provisioned dashboard folder.
-See [Dashboards](https://grafana.com/docs/grafana/latest/dashboards/).
-See [Dashboard JSON model](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/view-dashboard-json-model/).
-
-#### Configure plugins
-
-To install a plugin, create or update `.ddev/docker-compose.grafana_custom.yaml`.
-Replace `<plugin-id>` with the plugin ID.
-
-```yaml
-services:
-  grafana:
-    environment:
-      - GF_PLUGINS_PREINSTALL=<plugin-id>
-```
-
-To find the plugin ID:
-
-- visit [All plugins for Grafana](https://grafana.com/grafana/plugins/all-plugins/).
-- search for the desired plugin.
-- click the "Installation" tab.
-- Look at the "Install the Panel" code. In the below example, `grafana-clock-panel` is the plugin ID.
-
-    ```shell
-    grafana-cli plugins install grafana-clock-panel
-    ```
-
-#### Grafana Alloy
-
-[Grafana Alloy](https://grafana.com/docs/alloy/latest/) can collect, process, and export telemetry signals to scale and future-proof your observability approach.
-
-This addon configures Grafana Alloy to collect and process:
-
-- Docker logs (`alloy/docker.alloy`),
-- Alloy logs (`alloy/alloy-logs.alloy`)
-- Enable live debugging of Alloy pipelines, where supported
-- Adds a pipeline to a DDEV-supported Grafana Loki process
-
-To configure Alloy, add/update files in `.ddev/alloy`. By default, all files in this directory are loaded and processed.
-
-##### Usage
-
-Grafana Alloy runs within the process on its default port of `12345`.
-
-- To open the Grafana Alloy dashboard, run the following command:
-
-```shell
-ddev alloy
-```
-
-- To reload Alloy configuration, run the following command:
-
-```shell
-ddev alloy -r
-```
-
-#### Grafana Loki
-
-[Grafana Loki](https://grafana.com/docs/loki/latest/) is a set of open source components that can be composed into a fully featured logging stack.
-
-Grafana Loki listens on its default port of `3100`.
-To view processed logs, visit `Drilldown | Logs` in the Grafana dashboard.
-
-```shell
-ddev :3000/a/grafana-lokiexplore-app/explore
-```
-
-#### Grafana Tempo
-
-[Grafana Tempo](https://grafana.com/docs/tempo/latest/) is an open-source, easy-to-use, and high-scale distributed tracing backend.
-
-In this add-on, Grafana Alloy forwards open telemetry data it receives to Grafana Tempo for processing ([./alloy/otelcol.alloy](./alloy/otelcol.alloy)). Grafana Tempo datasource is pre-configured in Grafana allowing a centralized location for interacting with traces.
-
-- To configure Grafana Tempo, update `.ddev/tempo/tempo-config.yaml` and restart DDEV.
-- To forward Grafana Tempo traces to Grafana, update `.ddev/.env.tempo`
-
-```conf
-OTEL_SERVICE_NAME="tempo"
-OTEL_EXPORTER_OTLP_ENDPOINT="http://alloy:4318"
-```
 
 ## Credits
 

--- a/grafana/datasources/ddev-loki.yml
+++ b/grafana/datasources/ddev-loki.yml
@@ -3,11 +3,10 @@ apiVersion: 1
 
 datasources:
 - name: Loki
+  uid: loki
   type: loki
   access: proxy
-  orgId: 1
   url: http://loki:3100
   basicAuth: false
   isDefault: false
-  version: 1
   editable: false

--- a/grafana/datasources/ddev-mysql.yml
+++ b/grafana/datasources/ddev-mysql.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 
 datasources:
   - name: MySQL
+    uid: mysql
     type: mysql
     access: proxy
     url: db:3306

--- a/grafana/datasources/ddev-postgres.yml
+++ b/grafana/datasources/ddev-postgres.yml
@@ -3,6 +3,7 @@ apiVersion: 1
 
 datasources:
   - name: Postgres
+    uid: postgres
     type: postgres
     access: proxy
     url: db:5432

--- a/grafana/datasources/ddev-prometheus.yml
+++ b/grafana/datasources/ddev-prometheus.yml
@@ -3,11 +3,9 @@ apiVersion: 1
 
 datasources:
   - name: Prometheus
+    uid: prometheus
     type: prometheus
     url: http://prometheus:9090
-    orgId: 1
-    version: 1
-    uid: prometheus
     access: proxy
     isDefault: true
     basicAuth: false

--- a/grafana/datasources/ddev-tempo.yml
+++ b/grafana/datasources/ddev-tempo.yml
@@ -1,8 +1,9 @@
-#ddev-generated
+##ddev-generated
 apiVersion: 1
 
 datasources:
 - name: Tempo
+  uid: tempo
   type: tempo
   access: proxy
   url: http://tempo:3200

--- a/install.yaml
+++ b/install.yaml
@@ -19,6 +19,7 @@ project_files:
   - commands/host/alloy
   # The following files belong to the tempo feature
   - docker-compose.tempo.yaml
+  - grafana/datasources/ddev-tempo.yml
   - tempo/tempo-config.yaml
   # The following files belong to the nginx-prometheus-exporter feature.
   - docker-compose.nginx-prometheus-exporter.yaml

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -125,6 +125,24 @@ teardown() {
   assert_output --partial '"url":"http://prometheus:9090"'
 }
 
+@test "Grafana is pre-configured with DDEV MySQL datasource" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  # Query Grafana API for MySQL datasource
+  run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/mysql"
+  assert_output --partial '"name":"MySQL"'
+  assert_output --partial '"url":"db:3306"'
+  assert_output --partial '"database":"db"'
+  assert_output --partial '"user":"db"'
+}
+
 @test "Prometheus port is configurable" {
   set -eu -o pipefail
 
@@ -140,24 +158,6 @@ teardown() {
 
   run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/query"
   assert_output --partial "Prometheus Time Series Collection and Processing Server"
-}
-
-@test "Grafana is pre-configured with DDEV MySQL datasource" {
-  set -eu -o pipefail
-
-  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
-  run ddev add-on get "${DIR}"
-  assert_success
-
-  run ddev restart -y
-  assert_success
-
-  # Check MySQL settings
-  run ddev exec -s grafana cat /etc/grafana/provisioning/datasources/ddev-mysql.yml
-  assert_output --partial 'url: db:3306'
-  assert_output --partial 'database: db'
-  assert_output --partial 'user: db'
-  assert_output --partial 'password: db'
 }
 
 @test "Grafana is pre-configured with DDEV Postgres datasource" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -109,7 +109,7 @@ teardown() {
   assert_output --partial "<title>Grafana</title>"
 }
 
-@test "Grafana is pre-configured with Prometheus datasource" {
+@test "Grafana is pre-configured with datasources" {
   set -eu -o pipefail
 
   echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
@@ -123,6 +123,16 @@ teardown() {
   run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/prometheus"
   assert_output --partial '"name":"Prometheus"'
   assert_output --partial '"url":"http://prometheus:9090"'
+
+  # Query Grafana API for Loki datasource
+  run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/loki"
+  assert_output --partial '"name":"Loki"'
+  assert_output --partial '"url":"http://loki:3100"'
+
+  # Query Grafana API for Tempo datasource
+  run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/tempo"
+  assert_output --partial '"name":"Tempo"'
+  assert_output --partial '"url":"http://tempo:3200"'
 }
 
 @test "Grafana is pre-configured with DDEV MySQL datasource" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,21 +39,22 @@ setup() {
 }
 
 health_checks() {
-  prometheus_health_check
   grafana_health_check
+  prometheus_health_check
   loki_health_check
   alloy_health_check
   tempo_health_check
 }
 
+grafana_health_check() {
+  # Test the Grafana main page is accessible
+  run curl -sf "https://${PROJNAME}.ddev.site:3000"
+  assert_output --partial "<title>Grafana</title>"
+}
+
 prometheus_health_check() {
   run curl -sf "https://${PROJNAME}.ddev.site:9090/query"
   assert_output --partial "Prometheus Time Series Collection and Processing Server"
-}
-
-grafana_health_check() {
-  run curl -sf "https://${PROJNAME}.ddev.site:3000"
-  assert_output --partial "<title>Grafana</title>"
 }
 
 loki_health_check() {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -92,6 +92,23 @@ teardown() {
   health_checks
 }
 
+@test "Grafana port is configurable" {
+  set -eu -o pipefail
+
+  export GRAFANA_HTTPS_PORT=3043
+
+  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  ddev dotenv set .ddev/.env --grafana-https-port="${GRAFANA_HTTPS_PORT}"
+  run ddev restart -y
+  assert_success
+
+  run curl -sf "https://${PROJNAME}.ddev.site:${GRAFANA_HTTPS_PORT}"
+  assert_output --partial "<title>Grafana</title>"
+}
+
 @test "Prometheus port is configurable" {
   set -eu -o pipefail
 
@@ -107,23 +124,6 @@ teardown() {
 
   run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/query"
   assert_output --partial "Prometheus Time Series Collection and Processing Server"
-}
-
-@test "Grafana port is configurable" {
-  set -eu -o pipefail
-
-  export GRAFANA_HTTPS_PORT=3043
-
-  echo "# ddev add-on get ${GITHUB_REPO} with project ${PROJNAME} in $(pwd)" >&3
-  run ddev add-on get "${DIR}"
-  assert_success
-
-  ddev dotenv set .ddev/.env --grafana-https-port="${GRAFANA_HTTPS_PORT}"
-  run ddev restart -y
-  assert_success
-
-  run curl -sf "https://${PROJNAME}.ddev.site:${GRAFANA_HTTPS_PORT}"
-  assert_output --partial "Grafana"
 }
 
 @test "Grafana is pre-configured with Prometheus datasource" {


### PR DESCRIPTION
## The Issue

1.  **Incorrect Documentation Order:** The Grafana documentation appeared before the Prometheus documentation in the README.md, which is counterintuitive as Prometheus is often a primary data source for Grafana.
2.  **Missing UIDs in Datasource Configuration:** Grafana datasources were not provisioned with a UID. Without UIDs, importing dashboards that rely on specific datasources can lead to issues where Grafana is unable to map the dashboard to the intended data source.

## How This PR Solves The Issue

1.  **Reordered Documentation:** The Grafana documentation section has been moved to appear after the Prometheus documentation in the README.md file.
2.  **Added UIDs to Datasource Configuration:** UIDs have been added to each datasource configuration file (`.ddev/grafana/datasources/*.yml`).
3. **Improve Tests** Use Grafana HTTP APIs to query Grafrana configuration.


## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/refactor-grafana
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
