### PR TITLE
refactor: Improve Prometheus Health Check in Tests

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -50,6 +50,10 @@ prometheus_health_check() {
   # Test the Prometheus API is available
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/status/config"
   assert_output --partial '"status":"success"'
+
+  # Test Prometheus exposes metrics
+  run curl -sf "https://${PROJNAME}.ddev.site:9090/metrics"
+  assert_output --partial 'TYPE prometheus_build_info'
 }
 
 grafana_health_check() {
@@ -108,6 +112,10 @@ teardown() {
   # Test the Prometheus API is available
   run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/api/v1/status/config"
   assert_output --partial '"status":"success"'
+
+  # Test Prometheus exposes metrics
+  run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/metrics"
+  assert_output --partial 'TYPE prometheus_build_info'
 }
 
 @test "Grafana port is configurable" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -47,8 +47,9 @@ health_checks() {
 }
 
 prometheus_health_check() {
-  run curl -sf "https://${PROJNAME}.ddev.site:9090/query"
-  assert_output --partial "Prometheus Time Series Collection and Processing Server"
+  # Test the Prometheus API is available
+  run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/status/config"
+  assert_output --partial '"status":"success"'
 }
 
 grafana_health_check() {
@@ -104,8 +105,9 @@ teardown() {
   run ddev restart -y
   assert_success
 
-  run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/query"
-  assert_output --partial "Prometheus Time Series Collection and Processing Server"
+  # Test the Prometheus API is available
+  run curl -sf "https://${PROJNAME}.ddev.site:${PROMETHEUS_HTTPS_PORT}/api/v1/status/config"
+  assert_output --partial '"status":"success"'
 }
 
 @test "Grafana port is configurable" {


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where the Prometheus health check in our tests was not sufficiently validating the service's functionality. The previous check only verified the presence of a specific string in the response from the `/query` endpoint, which wasn't a reliable indicator of Prometheus's health or its ability to collect and expose metrics.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This change replaces the old check with two more robust checks:

1.  **API Availability:**  Verifies that the Prometheus API is available by querying the `/api/v1/status/config` endpoint and checking for a successful response with `\"status\":\"success\"`.
2.  **Metrics Exposure:** Confirms that Prometheus is exposing metrics by querying the `/metrics` endpoint and checking for the presence of the `TYPE prometheus_build_info` metric.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
