### PR TITLE
fix: node exporter

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,6 +16,10 @@ scrape_configs:
     metrics_path: '/metrics'
     static_configs:
       - targets: ['loki:3100']
+  # Get hardware and OS metrics exposed by *NIX kernels
+  - job_name: 'node-exporter'
+    static_configs:
+      - targets: ['node-exporter:9100']
   # Get exposed Nginx metrics
   - job_name: 'nginx'
     metrics_path: '/metrics'


### PR DESCRIPTION
## The Issue

The original `prometheus.yml` configuration did not include a scrape job configured to target the Node Exporter service, which runs on port 9100.  Without this configuration, Prometheus was unaware of the Node Exporter endpoint and therefore did not collect any metrics from it.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This pull request resolves an issue where the node-exporter metrics were not being scraped by Prometheus

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/refactor-node-exporter
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
