### PR TITLE
refactor: Grafana Tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     - [Grafana Alloy](#grafana-alloy)
       - [Usage](#usage)
   - [Grafana Loki](#grafana-loki)
-    - [Grafana Tempo](#grafana-tempo)
+  - [Grafana Tempo](#grafana-tempo)
   - [Prometheus](#prometheus)
     - [Customize Prometheus](#customize-prometheus)
     - [Addon: Nginx Exporter](#addon-nginx-exporter)
@@ -133,14 +133,19 @@ Key files include:
 - `docker-compose.grafana-loki.yaml`: loads Grafana Loki image
 - `loki/local-config.yaml`: Grafana Loki configuration file
 
-#### Grafana Tempo
+Key files include:
+
+- `docker-compose.grafana-loki.yaml`: loads Grafana Loki image
+- `loki/local-config.yaml`: Grafana Loki configuration file
+
+### Grafana Tempo
 
 [Grafana Tempo](https://grafana.com/docs/tempo/latest/) is an open-source, easy-to-use, and high-scale distributed tracing backend.
 
 In this add-on, Grafana Alloy forwards open telemetry data it receives to Grafana Tempo for processing ([./alloy/otelcol.alloy](./alloy/otelcol.alloy)). Grafana Tempo datasource is pre-configured in Grafana allowing a centralized location for interacting with traces.
 
 - To configure Grafana Tempo, update `.ddev/tempo/tempo-config.yaml` and restart DDEV.
-- To forward Grafana Tempo traces to Grafana, update `.ddev/.env.tempo`
+- To forward Grafana Tempo traces to Grafana, update `.ddev/.env.grafana-tempo`
 
 ```conf
 OTEL_SERVICE_NAME="tempo"

--- a/docker-compose.grafana-tempo.yaml
+++ b/docker-compose.grafana-tempo.yaml
@@ -1,7 +1,7 @@
 ##ddev-generated
 services:
-  tempo:
-    container_name: ddev-${DDEV_SITENAME}-tempo
+  grafana-tempo:
+    container_name: ddev-${DDEV_SITENAME}-grafana-tempo
     image: grafana/tempo:latest
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/grafana/datasources/ddev-tempo.yml
+++ b/grafana/datasources/ddev-tempo.yml
@@ -6,7 +6,7 @@ datasources:
   uid: tempo
   type: tempo
   access: proxy
-  url: http://tempo:3200
+  url: http://grafana-tempo:3200
   basicAuth: false
   jsonData:
     tracesToMetrics:

--- a/install.yaml
+++ b/install.yaml
@@ -18,7 +18,7 @@ project_files:
   - alloy
   - commands/host/alloy
   # The following files belong to the tempo feature
-  - docker-compose.tempo.yaml
+  - docker-compose.grafana-tempo.yaml
   - grafana/datasources/ddev-tempo.yml
   - tempo/tempo-config.yaml
   # The following files belong to the nginx-prometheus-exporter feature.

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -10,7 +10,7 @@ scrape_configs:
   # Add Tempo metrics
   - job_name: 'tempo'
     static_configs:
-      - targets: [ 'tempo:3200' ]
+      - targets: [ 'grafana-tempo:3200' ]
   # Add Loki metrics
   - job_name: 'loki'
     metrics_path: '/metrics'


### PR DESCRIPTION
## The Issue

The Grafana Tempo service was initially named `tempo` in `docker-compose.yaml`, while other configurations referenced `grafana-tempo`. This inconsistency could lead to:

-   Difficulty in understanding the service architecture
-   Errors in service discovery and communication
-   Misconfiguration of datasources and monitoring tools

## How This PR Solves The Issue

This pull request renames the Tempo service to `grafana-tempo` in `docker-compose.yaml` and updates all related configurations to reflect this change.

In additional, the tests were updated to be more resiliant.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/refactor-tempo
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
