### PR TITLE
refactor: Grafana Alloy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
     - [Configure Datasources](#configure-datasources)
     - [Configure Dashboards](#configure-dashboards)
     - [Configure plugins](#configure-plugins)
-    - [Grafana Alloy](#grafana-alloy)
-      - [Usage](#usage)
+  - [Grafana Alloy](#grafana-alloy)
+    - [Usage](#usage)
   - [Grafana Loki](#grafana-loki)
   - [Grafana Tempo](#grafana-tempo)
   - [Prometheus](#prometheus)
@@ -45,7 +45,6 @@ ddev restart
 After installation, make sure to commit the .ddev directory to version control.
 
 ## Tools
-
 
 ### Grafana
 
@@ -88,20 +87,20 @@ To find the plugin ID:
     grafana-cli plugins install grafana-clock-panel
     ```
 
-#### Grafana Alloy
+### Grafana Alloy
 
 [Grafana Alloy](https://grafana.com/docs/alloy/latest/) can collect, process, and export telemetry signals to scale and future-proof your observability approach.
 
 This addon configures Grafana Alloy to collect and process:
 
 - Docker logs (`alloy/docker.alloy`),
-- Alloy logs (`alloy/alloy-logs.alloy`)
+- Grafana Alloy logs (`alloy/alloy-logs.alloy`)
 - Enable live debugging of Alloy pipelines, where supported
 - Adds a pipeline to a DDEV-supported Grafana Loki process
 
-To configure Alloy, add/update files in `.ddev/alloy`. By default, all files in this directory are loaded and processed.
+To configure Grafana Alloy, add/update files in `.ddev/alloy`. By default, all files in this directory are loaded and processed.
 
-##### Usage
+#### Usage
 
 Grafana Alloy runs within the process on its default port of `12345`.
 
@@ -111,7 +110,7 @@ Grafana Alloy runs within the process on its default port of `12345`.
 ddev alloy
 ```
 
-- To reload Alloy configuration, run the following command:
+- To reload Grafana Alloy configuration, run the following command:
 
 ```shell
 ddev alloy -r
@@ -149,7 +148,7 @@ In this add-on, Grafana Alloy forwards open telemetry data it receives to Grafan
 
 ```conf
 OTEL_SERVICE_NAME="tempo"
-OTEL_EXPORTER_OTLP_ENDPOINT="http://alloy:4318"
+OTEL_EXPORTER_OTLP_ENDPOINT="http://grafana-alloy:4318"
 ```
 
 ### Prometheus

--- a/alloy/configurations.md
+++ b/alloy/configurations.md
@@ -1,9 +1,9 @@
 # Configuration
 <!-- ##ddev-generated -->
 
-This directory is contains Alloy configuration files.
+This directory is contains Grafana Alloy configuration files.
 
-Alloy finds `*.alloy` files (ignoring nested directories) and loads them as a single configuration source. However, component names must be unique across all Alloy configuration files, and configuration blocks must not be repeated.
+Grafana Alloy finds `*.alloy` files (ignoring nested directories) and loads them as a single configuration source. However, component names must be unique across all Grafana Alloy configuration files, and configuration blocks must not be repeated.
 
 See [Components](https://grafana.com/docs/alloy/latest/reference/components/).
 

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -2,7 +2,7 @@
 
 otelcol.receiver.otlp "default" {
   http {
-    endpoint="alloy:4318"
+    endpoint="grafana-alloy:4318"
   }
 
   output {

--- a/docker-compose.grafana-alloy.yaml
+++ b/docker-compose.grafana-alloy.yaml
@@ -1,7 +1,7 @@
 ##ddev-generated
 services:
-  alloy:
-    container_name: ddev-${DDEV_SITENAME}-alloy
+  grafana-alloy:
+    container_name: ddev-${DDEV_SITENAME}-grafana-alloy
     image: grafana/alloy:v1.8.3
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/install.yaml
+++ b/install.yaml
@@ -14,7 +14,7 @@ project_files:
   - docker-compose.grafana-loki.yaml
   - grafana/datasources/ddev-loki.yml
   - loki/local-config.yaml
-  - docker-compose.alloy.yaml
+  - docker-compose.grafana-alloy.yaml
   - alloy
   - commands/host/alloy
   # The following files belong to the tempo feature

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -6,7 +6,7 @@ scrape_configs:
   - job_name: 'alloy'
     metrics_path: '/metrics'
     static_configs:
-      - targets: ['alloy:12345']
+      - targets: ['grafana-alloy:12345']
   # Add Tempo metrics
   - job_name: 'tempo'
     static_configs:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -397,7 +397,7 @@ teardown() {
   assert_output --partial "${TARGET_METRIC}"
 
   # Query Grafana Loki ingests Grafana Alloy Logs
-  run ddev exec curl -sf "loki:3100/loki/api/v1/series"
+  run ddev exec curl -sf "grafana-loki:3100/loki/api/v1/series"
   assert_output --partial '"component":"alloy"'
   assert_output --partial '"service_name":"alloy"'
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -83,7 +83,7 @@ grafana_tempo_health_check() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  # [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {
@@ -374,6 +374,23 @@ teardown() {
   run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/tempo"
   assert_output --partial '"name":"Tempo"'
   assert_output --partial '"url":"http://grafana-tempo:3200"'
+}
+
+@test "Grafana Alloy command reloads configuration" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  grafana_alloy_health_check
+
+  # Confirm Alloy command successfully reloads configuration
+  run ddev alloy -r
+  assert_output --partial config reloaded
 }
 
 # bats test_tags=release

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -41,8 +41,8 @@ setup() {
 health_checks() {
   grafana_health_check
   prometheus_health_check
+  grafana_alloy_health_check
   grafana_loki_health_check
-  alloy_health_check
   grafana_tempo_health_check
 }
 
@@ -62,16 +62,16 @@ prometheus_health_check() {
   assert_output --partial 'TYPE prometheus_build_info'
 }
 
+grafana_alloy_health_check() {
+  # Test Grafana Alloy reports as healthy.
+  run curl -sf "https://${PROJNAME}.ddev.site:12345/-/healthy"
+  assert_output --partial 'All Alloy components are healthy'
+}
+
 grafana_loki_health_check() {
   # Test Grafana Loki exposes metrics
   run ddev exec curl -sf "grafana-loki:3100/metrics"
   assert_output --partial "HELP loki_build_info"
-}
-
-alloy_health_check() {
-  # Attempt to reload alloy configuration to prove the site is functioning.
-  run ddev alloy -r
-  assert_output --partial config reloaded
 }
 
 grafana_tempo_health_check() {
@@ -83,7 +83,7 @@ grafana_tempo_health_check() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  # [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where the Grafana Alloy service name and configuration paths were inconsistent, preventing proper metric collection and configuration reloading.

## How This PR Solves The Issue

This pull request makes the following changes to resolve the issue:

-   Renames the `alloy` service to `grafana-alloy` in `docker-compose.yaml`.
-   Updates the Grafana Alloy targets in `prometheus/prometheus.yml` to use `grafana-alloy`.
-   Updates Grafana Alloy OTLP endpoint to `grafana-alloy`
-   Renames `docker-compose.alloy.yaml` to `docker-compose.grafana-alloy.yaml`
-   Updates documentation that refers to "Alloy logs" to "Grafana Alloy logs"
-   Ensures the `grafana-alloy` service name is targeted correctly in health checks.

These changes ensure consistency in the service naming and configuration paths, allowing Grafana Alloy to function correctly and metrics to be properly collected and processed.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/refactor-grafana-alloy
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
