### PR TITLE
fix: Grafana Tempo service endpoint

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -59,7 +59,7 @@ otelcol.exporter.loki "default" {
 
 otelcol.exporter.otlphttp "tempo" {
     client {
-        endpoint = "http://tempo:4318"
+        endpoint = "http://grafana-tempo:4318"
         tls {
             insecure             = true
             insecure_skip_verify = true

--- a/tempo/tempo-config.yaml
+++ b/tempo/tempo-config.yaml
@@ -8,7 +8,7 @@ distributor:
     otlp:
       protocols:
         http:
-          endpoint: "tempo:4318"  # Replace 3200 with your desired port number
+          endpoint: "grafana-tempo:4318"  # Replace 3200 with your desired port number
 
 compactor:
   compaction:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -368,6 +368,10 @@ teardown() {
   export TEMPO_SERVER='grafana-tempo:3200'
   export TARGET_METRIC='tempo_build_info'
 
+  # Confirm Grafana Tempo OTEL endpoint is set
+  run grep 'endpoint: "grafana-tempo:4318"' .ddev/tempo/tempo-config.yaml
+  assert_success
+
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs "${TEMPO_SERVER}/metrics"
   assert_output --partial "HELP ${TARGET_METRIC}"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -371,6 +371,8 @@ teardown() {
   # Confirm Grafana Tempo OTEL endpoint is set
   run grep 'endpoint: "grafana-tempo:4318"' .ddev/tempo/tempo-config.yaml
   assert_success
+  run grep 'endpoint = "http://grafana-tempo:4318"' .ddev/alloy/otelcol.alloy
+  assert_success
 
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs "${TEMPO_SERVER}/metrics"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -365,10 +365,11 @@ teardown() {
   run ddev restart -y
   assert_success
 
+  export TEMPO_SERVER='grafana-tempo:3200'
   export TARGET_METRIC='tempo_build_info'
 
   # Check it exposes endpoint with statistics
-  run ddev exec curl -vs grafana-tempo:3200/metrics
+  run ddev exec curl -vs "${TEMPO_SERVER}/metrics"
   assert_output --partial "HELP ${TARGET_METRIC}"
 
   # Prometheus receives metrics
@@ -378,7 +379,7 @@ teardown() {
   # Query Grafana API for Tempo datasource
   run curl -sf "https://${PROJNAME}.ddev.site:3000/api/datasources/uid/tempo"
   assert_output --partial '"name":"Tempo"'
-  assert_output --partial '"url":"http://grafana-tempo:3200"'
+  assert_output --partial "url\":\"http://${TEMPO_SERVER}\""
 }
 
 @test "Grafana Alloy workflow is configured" {


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where the Tempo endpoint in the `tempo-config.yaml` and tests was not correctly configured for the ddev environment. This resulted in Tempo being unreachable and integration tests failing.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR updates the service name, and also expands tests to help prevent regressions.

## Manual Testing Instructions

1. Install this addon in existing project.

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/update-tempo-service-name
ddev restart
```
2.  **Run ddev:**  Ensure you have a ddev project set up. Run `ddev start`.
3.  **Run tests:** Execute the integration tests by running `./tests/test.bats`.

    *   Verify that all tests pass.  Specifically, observe the output to ensure there are no connection errors related to Tempo. The `teardown()` function includes checks to verify the proper configuration.
4.  **Inspect Tempo Configuration (Optional):**
    *   `ddev ssh` into the ddev environment.
    *   `cat .ddev/tempo/tempo-config.yaml` and confirm the `endpoint` is set to `grafana-tempo:4318`.
    *   `cat .ddev/alloy/scraper-otel.alloy` and confirm the `endpoint` is set to `http://grafana-tempo:4318`.
5.  **Verify Grafana Data Source:**
    *   Access your Grafana instance through your ddev project URL (usually something like `https://<project_name>.ddev.site:3000`).
    *   Navigate to "Data Sources".
    *   Find the Tempo data source and verify that its URL is `http://grafana-tempo:3200`.

## Automated Testing Overview

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
