### PR TITLE
fix: improve automatic logging attributes

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -41,6 +41,10 @@ otelcol.connector.spanlogs "default" {
   }
 }
 
+/*
+ * 'otelcol.processor.attributes' accepts telemetry data from other otelcol components and modifies attributes of a span, log, or metric.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.attributes/
+ */
 otelcol.processor.attributes "default" {
   // Extract app name from service.name attribute
   action {

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -27,6 +27,7 @@ otelcol.processor.batch "default" {
 otelcol.connector.spanlogs "default" {
   roots              = true
   spans              = true
+  events             = true
   labels             = ["srv", "tid"]
   span_attributes    = ["srv", "tid"]
   process_attributes = ["srv", "tid"]

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -26,14 +26,14 @@ otelcol.processor.batch "default" {
  */
 otelcol.connector.spanlogs "default" {
   roots              = true
-  events             = true
-  labels             = ["attribute1", "res_attribute1"]
-  span_attributes    = ["attribute1"]
-  process_attributes = ["res_attribute1"]
+  spans              = true
+  labels             = ["srv", "tid"]
+  span_attributes    = ["srv", "tid"]
+  process_attributes = ["srv", "tid"]
   event_attributes   = ["log.severity", "log.message"]
 
   overrides {
-    service_key = "service.key"
+    service_key = "srv"
   }
 
   output {
@@ -42,10 +42,32 @@ otelcol.connector.spanlogs "default" {
 }
 
 otelcol.processor.attributes "default" {
+  // Extract app name from service.name attribute
+  action {
+    key = "service.name"
+    from_attribute = "srv"
+    action = "upsert"
+  }
+
+  // Extract app name from service.name attribute
+  action {
+    key = "app"
+    from_attribute = "service.name"
+    action = "upsert"
+  }
+
+  // Extract app name from service.name attribute
+  action {
+    key = "app"
+    from_attribute = "service.name"
+    action = "upsert"
+  }
+
+  // Generate loki labels from OpenTelemetry attributes
   action {
     key = "loki.attribute.labels"
     action = "insert"
-    value = "attribute1"
+    value = "service.name,app"  // comma separated list
   }
 
   output {

--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -29,8 +29,6 @@ otelcol.connector.spanlogs "default" {
   spans              = true
   events             = true
   labels             = ["srv", "tid"]
-  span_attributes    = ["srv", "tid"]
-  process_attributes = ["srv", "tid"]
   event_attributes   = ["log.severity", "log.message"]
 
   overrides {


### PR DESCRIPTION
## The Issue

Currently, automatic logging of OTEL data appears as "unknown service".

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR adds additional attribues which also include maping `srv` as the service name.

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/fix--improve-automatic-logging-attributes
ddev restart
```

2. Generate OTEL metrics (EG. tyler36/ddev-site-metrics-laravel)
3. Visit `:3000/a/grafana-lokiexplore-app/explore` and confirm `service name`  does NOT display as `unknown service`

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
