### PR TITLE
feat: Alloy captures OTEL metrics and passes to Prometheus

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -6,6 +6,7 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
+    metrics = [otelcol.processor.batch.default.input]
     traces  = [otelcol.processor.batch.default.input]
   }
 }
@@ -16,6 +17,7 @@ otelcol.receiver.otlp "default" {
  */
 otelcol.processor.batch "default" {
   output {
+    metrics = [otelcol.exporter.prometheus.default.input]
     traces  = [otelcol.connector.spanlogs.default.input, otelcol.exporter.otlphttp.tempo.input]
   }
 }
@@ -76,6 +78,14 @@ otelcol.processor.attributes "default" {
   output {
     logs = [otelcol.exporter.loki.default.input]
   }
+}
+
+/**
+ * 'otelcol.exporter.prometheus' accepts OTLP-formatted metrics from other otelcol components, converts metrics to Prometheus-formatted metrics, and forwards the resulting metrics to prometheus components.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.prometheus/
+ */
+otelcol.exporter.prometheus "default" {
+  forward_to = [prometheus.remote_write.default.receiver]
 }
 
 otelcol.exporter.loki "default" {

--- a/alloy/prometheus.alloy
+++ b/alloy/prometheus.alloy
@@ -1,0 +1,11 @@
+// ##ddev-generated
+
+/**
+ * 'prometheus.remote_write' collects metrics sent from other components into a Write-Ahead Log (WAL) and forwards them over the network to a series of user-supplied endpoints.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/
+ */
+prometheus.remote_write "default" {
+  endpoint {
+    url = "http://prometheus:9090/api/v1/write"
+  }
+}

--- a/docker-compose.prometheus.yaml
+++ b/docker-compose.prometheus.yaml
@@ -13,3 +13,7 @@ services:
       environment:
         - VIRTUAL_HOST=$DDEV_HOSTNAME
         - HTTPS_EXPOSE=${PROMETHEUS_HTTPS_PORT:-9090}:9090
+      command:
+       - '--config.file=/etc/prometheus/prometheus.yml'
+       - '--web.enable-remote-write-receiver'
+       - '--enable-feature=remote-write-receiver'


### PR DESCRIPTION
## The Issue

Currently, the Alloy configuration lacks a proper exporter for OTLP metrics, preventing the collected metrics from being consumed by monitoring systems like Prometheus. This limits the observability of the application's performance and health.

## How This PR Solves The Issue

This pull request introduces changes to integrate the Prometheus exporter into the Alloy configuration, enabling the collection and forwarding of metrics to a Prometheus instance.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/feat--Alloy-captures-OTEL-metrics-and-passes-to-Prometheus
ddev restart
```

To verify the changes, follow these steps:

1.  **Start the ddev Environment:** Ensure your ddev environment is running with the new configuration using `ddev start`.

2.  **Generate Metrics:** Trigger the generation of metrics within your application. This can be done by sending requests to your application endpoints.
3.  **Access Prometheus:** Access the Prometheus UI by going to `http://prometheus.ddev.site:9090`.

4.  **Query Metrics:** In the Prometheus UI, query for metrics that should be exported from your application. If the integration is successful, you should see metrics being received by Prometheus. For example if you are generating the default metrics from the ddev-monitoring example, you should see `http_requests_total`.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
