### PR TITLE
refactor: remove "Unknown option" on Prometheus container'

### DIFF
--- a/docker-compose.prometheus.yaml
+++ b/docker-compose.prometheus.yaml
@@ -16,4 +16,3 @@ services:
       command:
        - '--config.file=/etc/prometheus/prometheus.yml'
        - '--web.enable-remote-write-receiver'
-       - '--enable-feature=remote-write-receiver'


### PR DESCRIPTION
## The Issue

Prometheus docker logs display the following warning:

```
msg="Unknown option for --enable-feature"
```

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR removes the unknown option from the container startup, thus removing the warning notice.

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/refactor--remove-"Unknown-option"-on-Prometheus-container'
ddev restart
```

2. Navigate to `Drilldown | Logs` in Grafana (`:3000/a/grafana-lokiexplore-app/explore`)

3. Confirm warning is NOT displayed.

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
