### PR TITLE
disable collectors for missing folders (WSL only?)

### DIFF
--- a/docker-compose.node-exporter.yaml
+++ b/docker-compose.node-exporter.yaml
@@ -17,5 +17,6 @@ services:
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
       - '--path.rootfs=/rootfs'
+      - '--path.udev.data=/rootfs/run/udev/data'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
       - '--web.listen-address=:${NODE_EXPORTER_HTTP_PORT:-9100}'

--- a/docker-compose.node-exporter.yaml
+++ b/docker-compose.node-exporter.yaml
@@ -19,4 +19,6 @@ services:
       - '--path.rootfs=/rootfs'
       - '--path.udev.data=/rootfs/run/udev/data'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
+      - '--no-collector.netstat'
+      - '--no-collector.softnet'
       - '--web.listen-address=:${NODE_EXPORTER_HTTP_PORT:-9100}'

--- a/docker-compose.node-exporter.yaml
+++ b/docker-compose.node-exporter.yaml
@@ -17,5 +17,5 @@ services:
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
       - '--path.rootfs=/rootfs'
-      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
       - '--web.listen-address=:${NODE_EXPORTER_HTTP_PORT:-9100}'


### PR DESCRIPTION
## The Issue

Node-exporter container reports warning and errors.

## How This PR Solves The Issue

This PR removes some errors and warnings.

- updating deprecated arguments
- additional volume
- disabling collectors

On my PC, this reduces startup errors to 3 (from 12) on my WSL2 install.

Happy to accept commits/PRs that improve collectors for other OSs.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix-node-exporter-logs-errors
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
