### PR TITLE
refactor: use LOKI_HTTP_PORT for Loki container

### DIFF
--- a/docker-compose.grafana-loki.yaml
+++ b/docker-compose.grafana-loki.yaml
@@ -11,7 +11,7 @@ services:
     - ".:/mnt/ddev_config"
     - "ddev-global-cache:/mnt/ddev-global-cache"
     - ./loki/local-config.yaml:/etc/loki/local-config.yaml
-    command: -config.file=/etc/loki/local-config.yaml
+    command: '-config.file=/etc/loki/local-config.yaml -config.expand-env=true'
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTPS_EXPOSE=3100:3100

--- a/docker-compose.grafana-loki.yaml
+++ b/docker-compose.grafana-loki.yaml
@@ -2,7 +2,7 @@
 services:
   grafana-loki:
     container_name: ddev-${DDEV_SITENAME}-grafana-loki
-    image: grafana/loki:3.4.2
+    image: grafana/loki:latest
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/loki/local-config.yaml
+++ b/loki/local-config.yaml
@@ -45,7 +45,7 @@ schema_config:
 pattern_ingester:
   enabled: true
   metric_aggregation:
-    loki_address: localhost:3100
+    loki_address: 127.0.0.1:${LOKI_HTTP_PORT:-3100}
 
 ruler:
   enable_alertmanager_discovery: true

--- a/loki/local-config.yaml
+++ b/loki/local-config.yaml
@@ -2,7 +2,7 @@
 auth_enabled: false
 
 server:
-  http_listen_port: 3100
+  http_listen_port: ${LOKI_HTTP_PORT:-3100}
   grpc_listen_port: 9096
   log_level: info
   grpc_server_max_concurrent_streams: 1000
@@ -30,7 +30,7 @@ limits_config:
   metric_aggregation_enabled: true
   allow_structured_metadata: true
   volume_enabled: true
-  retention_period: 24h   # 24h
+  retention_period: 24h # 24h
 
 schema_config:
   configs:
@@ -51,12 +51,8 @@ ruler:
   enable_alertmanager_discovery: true
   enable_api: true
 
-
-
-
 frontend:
   encoding: protobuf
-
 
 compactor:
   working_directory: /tmp/loki/retention


### PR DESCRIPTION
## The Issue

Loki port is hardcoded in serveral places. This makes it difficult to update.

## How This PR Solves The Issue

This PR uses an ENV value as port number. It defaults to `3100`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/loki-use-env-port
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
