### PR TITLE
revert: set static Grafana Loki tag

### DIFF
--- a/docker-compose.grafana-loki.yaml
+++ b/docker-compose.grafana-loki.yaml
@@ -2,7 +2,7 @@
 services:
   grafana-loki:
     container_name: ddev-${DDEV_SITENAME}-grafana-loki
-    image: grafana/loki:latest
+    image: grafana/loki:3.5.1
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}


### PR DESCRIPTION
## The Issue

#41 set the Grafana Loki image to `latest`

This causes a lot of "negative structured metadata bytes received error when no structured metadata sent on write path"  errors, although Loki _appears_ to function correctly.

See #grafana/loki/17371 


<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR sets `grafana/loki` to `3.5.1`, which is the latest version tag which does NOT contain the issue.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
