### PR TITLE
docs: Grafana Alerts

### DIFF
--- a/grafana/provisioning/alerting/contact-point.yaml
+++ b/grafana/provisioning/alerting/contact-point.yaml
@@ -1,0 +1,16 @@
+# ##ddev-generated
+
+# This file is an example of a contact-point configuration.
+# It was generated via the Grafana UI and exported into a configuration file.
+
+apiVersion: 1
+contactPoints:
+    - orgId: 1
+      name: Administrator
+      receivers:
+        - uid: p80i15qtcbfeo0
+          type: email
+          settings:
+            addresses: admin@example.com
+            singleEmail: false
+          disableResolveMessage: false


### PR DESCRIPTION
## The Issue

Grafana Logs displays the following warning:
 
`Failed to read alerting provisioning files from directory`

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR adds an example file that squashes the error message.
It demonstrates an email contact point that should be captured by Mailpit with the current configuration.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/docs--Grafana-Alerts
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
