### PR TITLE
feat: add privileges to MySQL-like DBs

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -54,5 +54,12 @@ post_install_actions:
         grep -q '#ddev-generated' docker-compose.postgres-exporter.yaml && rm docker-compose.postgres-exporter.yaml
         grep -q '#ddev-generated' grafana/provisioning/dashboards/postgres.json && rm grafana/provisioning/dashboards/postgres.json
         grep -q '#ddev-generated' prometheus/scrape-postgres-exporter.yml && rm prometheus/scrape-postgres-exporter.yml
+
+        if [[ "$DDEV_DATABASE" == *"mysql"* ]]; then
+          ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'db'@'%';"
+        fi
+        if [[ "$DDEV_DATABASE" == *"mariadb"* ]]; then
+          ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, REPLICA MONITOR ON *.* TO 'db'@'%';"
+        fi
     fi
   - ddev dotenv set .ddev/.env --node-exporter-http-port=9100 > /dev/null 2>&1


### PR DESCRIPTION
## The Issue

Docker displays some errors for the container:

MySQL:
"Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'REPLICA STATUS' at line 1"

MariaDB: "Error 1227 (42000): Access denied; you need (at least one of) the SLAVE MONITOR privilege(s) for this operation"

This prevents access to the full range of metrics, although most appear to work.

## How This PR Solves The Issue

This PR adds the required privileges thus preventing the error.

This increases `mysql_` prefixes for

- MySQL:  531 => 540
- MariaDB: 788 => 797

This was testing on

- MySQL `5.7`
- MySql `8.4`
- MariaDb `11.4`

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/feat-db-privilages
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
