### PR TITLE
fix: duplicate metrics with the same name and labels collected

### DIFF
--- a/docker-compose.node-exporter.yaml
+++ b/docker-compose.node-exporter.yaml
@@ -18,7 +18,7 @@ services:
       - '--path.sysfs=/host/sys'
       - '--path.rootfs=/rootfs'
       - '--path.udev.data=/rootfs/run/udev/data'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|mnt/wsl|run/user)($|/)'
       - '--no-collector.netstat'
       - '--no-collector.softnet'
       - '--web.listen-address=:${NODE_EXPORTER_HTTP_PORT:-9100}'


### PR DESCRIPTION
## The Issue

Node-exporter generates a lot duplicate errors:

"gauge:{value:0}} was collected before with the same name and label values\n* [from Gatherer #2] collected metric \"node_filesystem_readonly\" { label:{name:\"device\"  value:\"none\"}  label:{name:\"device_error\"  value:\"\"}  label:{name:\"fstype\"  value:\"tmpfs\"}  label:{name:\"mountpoint\"  value:\"/run/user\"}"

This usually occurs when:

- Multiple filesystems with the same labels are reported (e.g. device="none" and fstype="tmpfs" and mountpoint="/run/user").

- These metrics come from bind mounts or overlay filesystems—common in WSL, Docker, or Kubernetes environments.

- Node-exporter ends up collecting the same metrics multiple times from different mount paths that resolve to the same actual filesystem.

## How This PR Solves The Issue

This PR sets node-exporter to ignore WSL bind mounts and duplicate tmpfs.

This assumes the developer is running inside and with Docker Desktop, but should not cause an issue if the environment is different.

## Manual Testing Instructions

1. Install PR addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix--duplicate-metrics-with-the-same-name-and-labels-collected
ddev restart
```

1. Visit `:3000/a/grafana-lokiexplore-app/explore` and see if error appears.


## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
