### PR TITLE
fix: add additional Prometheus metrics

### DIFF
--- a/prometheus/scrapers/prometheus.yml
+++ b/prometheus/scrapers/prometheus.yml
@@ -1,0 +1,10 @@
+#ddev-generated
+
+# Prometheus
+# This file adds additional Prometheus metrics; 68 (default) to  256). Metrics are prefixed with `prometheus`.
+
+scrape_configs:
+  # Expose additional metrics
+  - job_name: 'prometheus'
+    static_configs:
+    - targets: ['localhost:9090']


### PR DESCRIPTION
## The Issue

While debugging Prometheus alerts, I discovered I was an expose the full range of Prometheus metrics.

The following alert expression was failing

`
absent(up{job="prometheus"})
`

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR configures Prometheus to scrape itself.

This increase the default metrics from 68, to 256

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
