### PR TITLE
fix: tweak default scrape interval

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,6 +1,6 @@
 ##ddev-generated
 global:
-  scrape_interval: 1m  # How often Prometheus scrapes data
+  scrape_interval: 30s  # How often Prometheus scrapes data
 
 scrape_configs:
 

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,6 +1,6 @@
 ##ddev-generated
 global:
-  scrape_interval: 5s  # How often Prometheus scrapes data
+  scrape_interval: 1m  # How often Prometheus scrapes data
 
 scrape_configs:
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -34,6 +34,10 @@ setup() {
   cd "${TESTDIR}"
   run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site
   assert_success
+
+  # We need to make sure Prometheus gets a change to scrape endpoints, so this should be longer than "scrape_interval"
+  # set in `prometheus/prometheus.yml`
+  ARBITRARY_WAIT_TIME=35
 }
 
 health_checks() {
@@ -290,6 +294,9 @@ teardown() {
   run ddev exec curl -vs apache-exporter:9117/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
 
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
+
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
   assert_output --partial "${TARGET_METRIC}"
@@ -309,6 +316,9 @@ teardown() {
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs nginx-exporter:9113/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
+
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
 
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
@@ -377,6 +387,9 @@ teardown() {
   run ddev exec curl -vs mysql-exporter:9104/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
 
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
+
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
   assert_output --partial "${TARGET_METRIC}"
@@ -410,6 +423,9 @@ teardown() {
   export TARGET_METRIC='mysql_up'
   run ddev exec curl -vs mysql-exporter:9104/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
+
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
 
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
@@ -445,6 +461,9 @@ teardown() {
   run ddev exec curl -vs mysql-exporter:9104/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
 
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
+
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
   assert_output --partial "${TARGET_METRIC}"
@@ -468,6 +487,9 @@ teardown() {
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs postgres-exporter:9187/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
+
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
 
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
@@ -525,6 +547,9 @@ teardown() {
   run ddev exec curl -vs node-exporter:9100/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
 
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
+
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
   assert_output --partial "${TARGET_METRIC}"
@@ -563,6 +588,9 @@ teardown() {
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs grafana-loki:3100/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
+
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
 
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
@@ -622,6 +650,9 @@ teardown() {
   # Check it exposes endpoint with statistics
   run ddev exec curl -vs grafana-alloy:12345/metrics
   assert_output --partial "HELP ${TARGET_METRIC}"
+
+  # Wait for an arbitrary amount of time for the trace to propagate.
+  sleep $ARBITRARY_WAIT_TIME
 
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"


### PR DESCRIPTION
## The Issue

Default scraping is currently set to 5s. This is a little overkill and can cause high memory / cpu use.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

THis PR set the global default scraping interval to 1 minute.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix--default-scrape-interval-is-1-minute
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
