### PR TITLE
fix: prevent port 3000 conflicts

### DIFF
--- a/docker-compose.grafana.yaml
+++ b/docker-compose.grafana.yaml
@@ -21,8 +21,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
-    ports:
-      - ${GRAFANA_HTTPS_PORT:-3000}
 
 volumes:
   grafana-storage:


### PR DESCRIPTION
## The Issue

Currently, port `3000`  is exposed on the host level. This can cause conflicts if other services wish to use the same port.

## How This PR Solves The Issue

This PR exposes the port within the container only, while still allowing access via domain name.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
