### PR TITLE
fix: node exporter targets host system

### DIFF
--- a/docker-compose.node-exporter.yaml
+++ b/docker-compose.node-exporter.yaml
@@ -10,15 +10,9 @@ services:
     volumes:
       - ".:/mnt/ddev_config"
       - "ddev-global-cache:/mnt/ddev-global-cache"
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
+      - "/:/host:ro"
     command:
-      - '--path.procfs=/host/proc'
-      - '--path.sysfs=/host/sys'
-      - '--path.rootfs=/rootfs'
-      - '--path.udev.data=/rootfs/run/udev/data'
+      - '--path.rootfs=/host'
+      - '--path.udev.data=/host/run/udev/data'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc|mnt/wsl|run/user)($|/)'
-      - '--no-collector.netstat'
-      - '--no-collector.softnet'
       - '--web.listen-address=:${NODE_EXPORTER_HTTP_PORT:-9100}'


### PR DESCRIPTION
## The Issue

The node_exporter is designed to monitor the host system. Deploying in containers requires extra care in order to avoid monitoring the container itself.

## How This PR Solves The Issue

This PR attempts to follow the advise as given in https://github.com/prometheus/node_exporter#docker

In my prefered workflow, this PR results in node_exporter displaying stats for WSL (such as uptime). 

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
