### PR TITLE
bump: node-exporter dashboard

### DIFF
--- a/grafana/provisioning/dashboards/node.json
+++ b/grafana/provisioning/dashboards/node.json
@@ -1,5 +1,54 @@
 {
   "help": "##ddev-generated",
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.6.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -25,7 +74,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 4,
+  "id": null,
   "links": [
     {
       "icon": "external link",
@@ -61,7 +110,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Resource pressure via PSI",
       "fieldConfig": {
@@ -129,10 +178,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "irate(node_pressure_cpu_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
@@ -145,10 +190,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "irate(node_pressure_memory_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
@@ -162,10 +203,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "irate(node_pressure_io_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
@@ -179,10 +216,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "irate(node_pressure_irq_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
@@ -202,7 +235,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Overall CPU busy percentage (averaged across all cores)",
       "fieldConfig": {
@@ -269,10 +302,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\", instance=\"$node\"}[$__rate_interval])))",
@@ -291,7 +320,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "System load  over all CPU cores together",
       "fieldConfig": {
@@ -358,10 +387,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "scalar(node_load1{instance=\"$node\",job=\"$job\"}) * 100 / count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu))",
@@ -380,7 +405,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Real RAM usage excluding cache and reclaimable memory",
       "fieldConfig": {
@@ -437,10 +462,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "(1 - (node_memory_MemAvailable_bytes{instance=\"$node\", job=\"$job\"} / node_memory_MemTotal_bytes{instance=\"$node\", job=\"$job\"})) * 100",
@@ -459,7 +480,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of swap space currently used by the system",
       "fieldConfig": {
@@ -526,10 +547,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "((node_memory_SwapTotal_bytes{instance=\"$node\",job=\"$job\"} - node_memory_SwapFree_bytes{instance=\"$node\",job=\"$job\"}) / (node_memory_SwapTotal_bytes{instance=\"$node\",job=\"$job\"})) * 100",
@@ -546,7 +563,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Used Root FS",
       "fieldConfig": {
@@ -613,10 +630,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "(\n  (node_filesystem_size_bytes{instance=\"$node\", job=\"$job\", mountpoint=\"/\", fstype!=\"rootfs\"}\n   - node_filesystem_avail_bytes{instance=\"$node\", job=\"$job\", mountpoint=\"/\", fstype!=\"rootfs\"})\n  / node_filesystem_size_bytes{instance=\"$node\", job=\"$job\", mountpoint=\"/\", fstype!=\"rootfs\"}\n) * 100\n",
@@ -634,7 +647,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -693,10 +706,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu))",
@@ -712,7 +721,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -772,10 +781,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "node_reboot_required{instance=\"$node\",job=\"$job\"}",
@@ -792,7 +797,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -856,10 +861,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "node_time_seconds{instance=\"$node\",job=\"$job\"} - node_boot_time_seconds{instance=\"$node\",job=\"$job\"}",
@@ -876,7 +877,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -944,10 +945,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "node_filesystem_size_bytes{instance=\"$node\",job=\"$job\",mountpoint=\"/\",fstype!=\"rootfs\"}",
@@ -966,7 +963,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1030,10 +1027,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"}",
@@ -1050,7 +1043,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "",
       "fieldConfig": {
@@ -1114,10 +1107,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "node_memory_SwapTotal_bytes{instance=\"$node\",job=\"$job\"}",
@@ -1147,7 +1136,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "CPU time spent busy vs idle, split by activity type",
       "fieldConfig": {
@@ -1303,10 +1292,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "exemplar": false,
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"system\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
@@ -1320,10 +1305,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"user\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
           "format": "time_series",
@@ -1335,10 +1316,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"iowait\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
           "format": "time_series",
@@ -1349,10 +1326,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=~\".*irq\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
           "format": "time_series",
@@ -1363,10 +1336,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\",  mode!='idle',mode!='user',mode!='system',mode!='iowait',mode!='irq',mode!='softirq'}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
           "format": "time_series",
@@ -1377,10 +1346,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "sum(irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\", mode=\"idle\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
           "format": "time_series",
@@ -1397,7 +1362,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "RAM and swap usage overview, including caches",
       "fieldConfig": {
@@ -1549,10 +1514,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"}",
           "format": "time_series",
@@ -1564,10 +1525,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"} - node_memory_MemFree_bytes{instance=\"$node\",job=\"$job\"} - (node_memory_Cached_bytes{instance=\"$node\",job=\"$job\"} + node_memory_Buffers_bytes{instance=\"$node\",job=\"$job\"} + node_memory_SReclaimable_bytes{instance=\"$node\",job=\"$job\"})",
           "format": "time_series",
@@ -1579,10 +1536,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "node_memory_Cached_bytes{instance=\"$node\",job=\"$job\"} + node_memory_Buffers_bytes{instance=\"$node\",job=\"$job\"} + node_memory_SReclaimable_bytes{instance=\"$node\",job=\"$job\"}",
           "format": "time_series",
@@ -1593,10 +1546,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "node_memory_MemFree_bytes{instance=\"$node\",job=\"$job\"}",
           "format": "time_series",
@@ -1607,10 +1556,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "(node_memory_SwapTotal_bytes{instance=\"$node\",job=\"$job\"} - node_memory_SwapFree_bytes{instance=\"$node\",job=\"$job\"})",
           "format": "time_series",
@@ -1627,7 +1572,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Per-interface network traffic (receive and transmit) in bits per second",
       "fieldConfig": {
@@ -1718,10 +1663,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "rate(node_network_receive_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -1732,10 +1673,6 @@
           "step": 240
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "rate(node_network_transmit_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])*8",
           "format": "time_series",
@@ -1752,7 +1689,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "prometheus"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of filesystem space used for each mounted device",
       "fieldConfig": {
@@ -1832,10 +1769,6 @@
       "pluginVersion": "11.6.1",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
           "editorMode": "code",
           "expr": "((node_filesystem_size_bytes{instance=\"$node\", job=\"$job\", device!~\"rootfs\"} - node_filesystem_avail_bytes{instance=\"$node\", job=\"$job\", device!~\"rootfs\"}) / node_filesystem_size_bytes{instance=\"$node\", job=\"$job\", device!~\"rootfs\"}) * 100",
           "format": "time_series",
@@ -1862,7 +1795,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "CPU time usage split by state, normalized across all CPU cores",
           "fieldConfig": {
@@ -2080,8 +2013,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -2097,10 +2029,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"system\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2112,10 +2040,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"user\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2126,10 +2050,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"nice\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2140,10 +2060,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"iowait\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2154,10 +2070,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"irq\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2168,10 +2080,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"softirq\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2182,10 +2090,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"steal\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2196,10 +2100,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum(irate(node_cpu_seconds_total{mode=\"idle\",instance=\"$node\",job=\"$job\"}[$__rate_interval])) / scalar(count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu)))",
               "format": "time_series",
@@ -2211,10 +2111,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "sum by(instance) (irate(node_cpu_guest_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])) / on(instance) group_left sum by (instance)((irate(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval]))) > 0",
               "format": "time_series",
@@ -2232,7 +2128,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Breakdown of physical memory and swap usage. Hardware-detected memory errors are also displayed",
           "fieldConfig": {
@@ -2601,8 +2497,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -2618,10 +2513,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"} - node_memory_MemFree_bytes{instance=\"$node\",job=\"$job\"} - node_memory_Buffers_bytes{instance=\"$node\",job=\"$job\"} - node_memory_Cached_bytes{instance=\"$node\",job=\"$job\"} - node_memory_Slab_bytes{instance=\"$node\",job=\"$job\"} - node_memory_PageTables_bytes{instance=\"$node\",job=\"$job\"} - node_memory_SwapCached_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2633,10 +2524,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_PageTables_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2648,10 +2535,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_SwapCached_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2662,10 +2545,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Slab_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2677,10 +2556,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Cached_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2692,10 +2567,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Buffers_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2707,10 +2578,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_MemFree_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2722,10 +2589,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "(node_memory_SwapTotal_bytes{instance=\"$node\",job=\"$job\"} - node_memory_SwapFree_bytes{instance=\"$node\",job=\"$job\"})",
               "format": "time_series",
@@ -2737,10 +2600,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_HardwareCorrupted_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -2758,7 +2617,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Incoming and outgoing network traffic per interface",
           "fieldConfig": {
@@ -2830,7 +2689,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 853
+            "y": 303
           },
           "id": 84,
           "options": {
@@ -2838,8 +2697,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -2854,10 +2712,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -2868,10 +2722,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])*8",
               "format": "time_series",
@@ -2888,7 +2738,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Network interface utilization as a percentage of its maximum capacity",
           "fieldConfig": {
@@ -2960,7 +2810,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 853
+            "y": 303
           },
           "id": 338,
           "options": {
@@ -2968,8 +2818,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -2984,10 +2833,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "(rate(node_network_receive_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])\n / ignoring(speed) node_network_speed_bytes{instance=\"$node\",job=\"$job\", speed!=\"-1\"}) * 100",
               "format": "time_series",
@@ -2998,10 +2843,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "(rate(node_network_transmit_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])\n / ignoring(speed) node_network_speed_bytes{instance=\"$node\",job=\"$job\", speed!=\"-1\"}) * 100",
               "format": "time_series",
@@ -3019,7 +2860,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Disk I/O operations per second for each device",
           "fieldConfig": {
@@ -3091,7 +2932,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 865
+            "y": 315
           },
           "id": 229,
           "options": {
@@ -3099,8 +2940,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3115,10 +2955,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_reads_completed_total{instance=\"$node\",job=\"$job\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 4,
@@ -3128,10 +2964,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_writes_completed_total{instance=\"$node\",job=\"$job\",device=~\"$diskdevices\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -3147,7 +2979,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Disk I/O throughput per device",
           "fieldConfig": {
@@ -3219,7 +3051,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 865
+            "y": 315
           },
           "id": 42,
           "options": {
@@ -3227,8 +3059,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3243,10 +3074,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_read_bytes_total{instance=\"$node\",job=\"$job\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -3258,10 +3085,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_written_bytes_total{instance=\"$node\",job=\"$job\",device=~\"$diskdevices\"}[$__rate_interval])",
               "format": "time_series",
@@ -3279,7 +3102,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Amount of available disk space per mounted filesystem, excluding rootfs. Based on block availability to non-root users",
           "fieldConfig": {
@@ -3339,7 +3162,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 877
+            "y": 327
           },
           "id": 43,
           "options": {
@@ -3347,8 +3170,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3363,10 +3185,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_avail_bytes{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -3379,10 +3197,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_free_bytes{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -3394,10 +3208,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_size_bytes{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -3415,7 +3225,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Disk usage (used = total - available) per mountpoint",
           "fieldConfig": {
@@ -3475,7 +3285,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 877
+            "y": 327
           },
           "id": 156,
           "options": {
@@ -3483,8 +3293,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3499,10 +3308,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_size_bytes{instance=\"$node\",job=\"$job\",device!~'rootfs'} - node_filesystem_avail_bytes{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -3519,7 +3324,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Percentage of time the disk was actively processing I/O operations",
           "fieldConfig": {
@@ -3579,7 +3384,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 889
+            "y": 339
           },
           "id": 127,
           "options": {
@@ -3587,8 +3392,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3603,10 +3407,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_io_time_seconds_total{instance=\"$node\",job=\"$job\",device=~\"$diskdevices\"} [$__rate_interval])",
               "format": "time_series",
@@ -3625,7 +3425,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "How often tasks experience CPU, memory, or I/O delays. “Some” indicates partial slowdown; “Full” indicates all tasks are stalled. Based on Linux PSI metrics:\nhttps://docs.kernel.org/accounting/psi.html",
           "fieldConfig": {
@@ -3709,7 +3509,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 889
+            "y": 339
           },
           "id": 322,
           "options": {
@@ -3717,8 +3517,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3733,10 +3532,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_cpu_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3747,10 +3542,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_memory_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3762,10 +3553,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_memory_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3777,10 +3564,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_io_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3792,10 +3575,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_io_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3807,10 +3586,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_pressure_irq_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -3842,7 +3617,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Displays committed memory usage versus the system's commit limit. Exceeding the limit is allowed under Linux overcommit policies but may increase OOM risks under high load",
           "fieldConfig": {
@@ -3922,7 +3697,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 602
           },
           "id": 135,
           "options": {
@@ -3930,8 +3705,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -3947,10 +3721,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Committed_AS_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -3961,10 +3731,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_CommitLimit_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -3981,7 +3747,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Memory currently dirty (modified but not yet written to disk), being actively written back, or held by writeback buffers. High dirty or writeback memory may indicate disk I/O pressure or delayed flushing",
           "fieldConfig": {
@@ -4041,7 +3807,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 602
           },
           "id": 130,
           "options": {
@@ -4049,8 +3815,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4065,10 +3830,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Writeback_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4079,10 +3840,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_WritebackTmp_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4093,10 +3850,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Dirty_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4107,10 +3860,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_NFS_Unstable_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4128,7 +3877,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Kernel slab memory usage, separated into reclaimable and non-reclaimable categories. Reclaimable memory can be freed under memory pressure (e.g., caches), while unreclaimable memory is locked by the kernel for core functions",
           "fieldConfig": {
@@ -4188,7 +3937,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 762
+            "y": 802
           },
           "id": 131,
           "options": {
@@ -4196,8 +3945,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4212,10 +3960,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_SUnreclaim_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4226,10 +3970,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_SReclaimable_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4246,7 +3986,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Memory used for mapped files (such as libraries) and shared memory (shmem and tmpfs), including variants backed by huge pages",
           "fieldConfig": {
@@ -4306,7 +4046,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 762
+            "y": 802
           },
           "id": 138,
           "options": {
@@ -4314,8 +4054,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4331,10 +4070,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Mapped_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4345,10 +4080,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Shmem_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4359,10 +4090,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_ShmemHugePages_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4374,10 +4101,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_ShmemPmdMapped_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4395,7 +4118,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Proportion of memory pages in the kernel's active and inactive LRU lists relative to total RAM. Active pages have been recently used, while inactive pages are less recently accessed but still resident in memory",
           "fieldConfig": {
@@ -4486,7 +4209,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 772
+            "y": 812
           },
           "id": 136,
           "options": {
@@ -4494,8 +4217,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4511,10 +4233,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "(node_memory_Inactive_bytes{instance=\"$node\",job=\"$job\"}) \n/ \n(node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"})",
               "format": "time_series",
@@ -4525,10 +4243,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "(node_memory_Active_bytes{instance=\"$node\",job=\"$job\"}) \n/ \n(node_memory_MemTotal_bytes{instance=\"$node\",job=\"$job\"})\n",
               "format": "time_series",
@@ -4545,7 +4259,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Breakdown of memory pages in the kernel's active and inactive LRU lists, separated by anonymous (heap, tmpfs) and file-backed (caches, mmap) pages.",
           "fieldConfig": {
@@ -4605,7 +4319,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 772
+            "y": 812
           },
           "id": 191,
           "options": {
@@ -4613,8 +4327,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4630,10 +4343,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Inactive_file_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4645,10 +4354,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Inactive_anon_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4660,10 +4365,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Active_file_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4675,10 +4376,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Active_anon_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4696,7 +4393,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks kernel memory used for CPU-local structures, per-thread stacks, and bounce buffers used for I/O on DMA-limited devices. These areas are typically small but critical for low-level operations",
           "fieldConfig": {
@@ -4756,7 +4453,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 782
+            "y": 822
           },
           "id": 160,
           "options": {
@@ -4764,8 +4461,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4781,10 +4477,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_KernelStack_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4795,10 +4487,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Percpu_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4810,10 +4498,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Bounce_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4832,7 +4516,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Usage of the kernel's vmalloc area, which provides virtual memory allocations for kernel modules and drivers. Includes total, used, and largest free block sizes",
           "fieldConfig": {
@@ -4922,7 +4606,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 782
+            "y": 822
           },
           "id": 70,
           "options": {
@@ -4930,8 +4614,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -4946,10 +4629,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_VmallocChunk_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4961,10 +4640,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_VmallocTotal_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4976,10 +4651,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_VmallocUsed_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -4997,7 +4668,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Memory used by anonymous pages (not backed by files), including standard and huge page allocations. Includes heap, stack, and memory-mapped anonymous regions",
           "fieldConfig": {
@@ -5057,7 +4728,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 792
+            "y": 832
           },
           "id": 129,
           "options": {
@@ -5065,8 +4736,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5081,10 +4751,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_AnonHugePages_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5095,10 +4761,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_AnonPages_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5115,7 +4777,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Memory that is locked in RAM and cannot be swapped out. Includes both kernel-unevictable memory and user-level memory locked with mlock()",
           "fieldConfig": {
@@ -5191,7 +4853,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 792
+            "y": 832
           },
           "id": 137,
           "options": {
@@ -5199,8 +4861,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5216,10 +4877,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Unevictable_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5230,10 +4887,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_Mlocked_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5250,7 +4903,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "How much memory is directly mapped in the kernel using different page sizes (4K, 2M, 1G). Helps monitor large page utilization in the direct map region",
           "fieldConfig": {
@@ -5585,7 +5238,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 802
+            "y": 842
           },
           "id": 128,
           "options": {
@@ -5593,8 +5246,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5609,10 +5261,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_DirectMap1G_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5623,10 +5271,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_DirectMap2M_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5638,10 +5282,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_DirectMap4k_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5659,7 +5299,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Displays HugePages memory usage in bytes, including allocated, free, reserved, and surplus memory. All values are calculated based on the number of huge pages multiplied by their configured size",
           "fieldConfig": {
@@ -5719,7 +5359,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 802
+            "y": 842
           },
           "id": 140,
           "options": {
@@ -5727,8 +5367,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5743,10 +5382,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_HugePages_Free{instance=\"$node\",job=\"$job\"} * node_memory_Hugepagesize_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5757,10 +5392,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_HugePages_Rsvd{instance=\"$node\",job=\"$job\"} * node_memory_Hugepagesize_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5771,10 +5402,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_HugePages_Surp{instance=\"$node\",job=\"$job\"} * node_memory_Hugepagesize_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5785,10 +5412,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_memory_HugePages_Total{instance=\"$node\",job=\"$job\"} * node_memory_Hugepagesize_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -5820,7 +5443,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of memory pages being read from or written to disk (page-in and page-out operations). High page-out may indicate memory pressure or swapping activity",
           "fieldConfig": {
@@ -5892,7 +5515,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 603
           },
           "id": 176,
           "options": {
@@ -5900,8 +5523,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -5916,10 +5538,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgpgin{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -5930,10 +5548,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgpgout{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -5950,7 +5564,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate at which memory pages are being swapped in from or out to disk. High swap-out activity may indicate memory pressure",
           "fieldConfig": {
@@ -6022,7 +5636,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 603
           },
           "id": 22,
           "options": {
@@ -6030,8 +5644,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6046,10 +5659,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pswpin{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6060,10 +5669,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pswpout{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6080,7 +5685,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of memory page faults, split into total, major (disk-backed), and derived minor (non-disk) faults. High major fault rates may indicate memory pressure or insufficient RAM",
           "fieldConfig": {
@@ -6177,7 +5782,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 693
+            "y": 783
           },
           "id": 175,
           "options": {
@@ -6185,8 +5790,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6202,10 +5806,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgfault{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6217,10 +5817,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgmajfault{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6232,10 +5828,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_pgfault{instance=\"$node\",job=\"$job\"}[$__rate_interval])  - irate(node_vmstat_pgmajfault{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6253,7 +5845,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of Out-of-Memory (OOM) kill events. A non-zero value indicates the kernel has terminated one or more processes due to memory exhaustion",
           "fieldConfig": {
@@ -6329,7 +5921,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 693
+            "y": 783
           },
           "id": 307,
           "options": {
@@ -6337,8 +5929,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6353,10 +5944,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_vmstat_oom_kill{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -6388,7 +5975,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks the system clock's estimated and maximum error, as well as its offset from the reference clock (e.g., via NTP). Useful for detecting synchronization drift",
           "fieldConfig": {
@@ -6447,7 +6034,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 604
           },
           "id": 260,
           "options": {
@@ -6455,8 +6042,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6471,10 +6057,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_estimated_error_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6487,10 +6069,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_offset_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6503,10 +6081,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_maxerror_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6525,7 +6099,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "NTP phase-locked loop (PLL) time constant used by the kernel to control time adjustments. Lower values mean faster correction but less stability",
           "fieldConfig": {
@@ -6584,7 +6158,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 604
           },
           "id": 291,
           "options": {
@@ -6592,8 +6166,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6608,10 +6181,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_loop_time_constant{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6629,7 +6198,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows whether the system clock is synchronized to a reliable time source, and the current frequency correction ratio applied by the kernel to maintain synchronization",
           "fieldConfig": {
@@ -6688,7 +6257,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 484
+            "y": 754
           },
           "id": 168,
           "options": {
@@ -6696,8 +6265,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6712,10 +6280,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_sync_status{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6727,10 +6291,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_frequency_adjustment_ratio{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6742,10 +6302,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_tick_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6758,10 +6314,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_tai_offset_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6780,7 +6332,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Displays the PPS signal's frequency offset and stability (jitter) in hertz. Useful for monitoring high-precision time sources like GPS or atomic clocks",
           "fieldConfig": {
@@ -6839,7 +6391,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 484
+            "y": 754
           },
           "id": 333,
           "options": {
@@ -6847,8 +6399,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6863,10 +6414,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_pps_frequency_hertz{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6878,10 +6425,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_pps_stability_hertz{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6899,7 +6442,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks PPS signal timing jitter and shift compared to system clock",
           "fieldConfig": {
@@ -6958,7 +6501,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 494
+            "y": 764
           },
           "id": 334,
           "options": {
@@ -6966,8 +6509,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -6982,10 +6524,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_pps_jitter_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -6997,10 +6535,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_timex_pps_shift_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7018,7 +6552,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of PPS synchronization diagnostics including calibration events, jitter violations, errors, and frequency stability exceedances",
           "fieldConfig": {
@@ -7081,7 +6615,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 494
+            "y": 764
           },
           "id": 335,
           "options": {
@@ -7089,8 +6623,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7105,10 +6638,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_timex_pps_calibration_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7120,10 +6649,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_timex_pps_error_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7135,10 +6660,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_timex_pps_stability_exceeded_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7151,10 +6672,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_timex_pps_jitter_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7187,7 +6704,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Processes currently in runnable or blocked states. Helps identify CPU contention or I/O wait bottlenecks.",
           "fieldConfig": {
@@ -7251,7 +6768,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 605
           },
           "id": 62,
           "options": {
@@ -7259,8 +6776,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7275,10 +6791,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_procs_blocked{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7289,10 +6801,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_procs_running{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7309,7 +6817,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Current number of processes in each state (e.g., running, sleeping, zombie). Requires --collector.processes to be enabled in node_exporter",
           "fieldConfig": {
@@ -7454,7 +6962,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 605
           },
           "id": 315,
           "options": {
@@ -7462,8 +6970,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7478,10 +6985,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_processes_state{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7499,7 +7002,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of new processes being created on the system (forks/sec).",
           "fieldConfig": {
@@ -7559,7 +7062,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 425
+            "y": 635
           },
           "id": 148,
           "options": {
@@ -7567,8 +7070,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7583,10 +7085,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_forks_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7604,7 +7102,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows CPU saturation per core, calculated as the proportion of time spent waiting to run relative to total time demanded (running + waiting).",
           "fieldConfig": {
@@ -7680,7 +7178,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 425
+            "y": 635
           },
           "id": 305,
           "options": {
@@ -7688,8 +7186,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7704,10 +7201,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_schedstat_running_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7720,10 +7213,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_schedstat_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -7736,10 +7225,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_schedstat_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])\n/\n(irate(node_schedstat_running_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval]) + irate(node_schedstat_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval]))\n",
               "format": "time_series",
@@ -7758,7 +7243,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of active PIDs on the system and the configured maximum allowed. Useful for detecting PID exhaustion risk. Requires --collector.processes in node_exporter",
           "fieldConfig": {
@@ -7848,7 +7333,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 435
+            "y": 645
           },
           "id": 313,
           "options": {
@@ -7856,8 +7341,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -7872,10 +7356,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_processes_pids{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7887,10 +7367,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_processes_max_processes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -7908,7 +7384,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of active threads on the system and the configured thread limit. Useful for monitoring thread pressure. Requires --collector.processes in node_exporter",
           "fieldConfig": {
@@ -7998,7 +7474,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 435
+            "y": 645
           },
           "id": 314,
           "options": {
@@ -8006,8 +7482,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8022,10 +7497,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_processes_threads{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8037,10 +7508,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_processes_max_threads{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8072,7 +7539,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Per-second rate of context switches and hardware interrupts. High values may indicate intense CPU or I/O activity",
           "fieldConfig": {
@@ -8132,7 +7599,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 686
           },
           "id": 8,
           "options": {
@@ -8140,8 +7607,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8156,10 +7622,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_context_switches_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -8170,10 +7632,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_intr_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -8191,7 +7649,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "System load average over 1, 5, and 15 minutes. Reflects the number of active or waiting processes. Values above CPU core count may indicate overload",
           "fieldConfig": {
@@ -8281,7 +7739,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 686
           },
           "id": 7,
           "options": {
@@ -8289,8 +7747,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8305,10 +7762,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_load1{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8319,10 +7772,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_load5{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8333,10 +7782,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_load15{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8347,10 +7792,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "count(count(node_cpu_seconds_total{instance=\"$node\",job=\"$job\"}) by (cpu))",
               "format": "time_series",
@@ -8368,7 +7809,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Real-time CPU frequency scaling per core, including average minimum and maximum allowed scaling frequencies",
           "fieldConfig": {
@@ -8494,7 +7935,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 396
+            "y": 696
           },
           "id": 321,
           "options": {
@@ -8502,8 +7943,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8518,10 +7958,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_cpu_scaling_frequency_hertz{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8534,10 +7970,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "avg(node_cpu_scaling_frequency_max_hertz{instance=\"$node\",job=\"$job\"})",
               "format": "time_series",
@@ -8550,10 +7982,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "avg(node_cpu_scaling_frequency_min_hertz{instance=\"$node\",job=\"$job\"})",
               "format": "time_series",
@@ -8572,7 +8000,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of scheduling timeslices executed per CPU. Reflects how frequently the scheduler switches tasks on each core",
           "fieldConfig": {
@@ -8631,7 +8059,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 396
+            "y": 696
           },
           "id": 306,
           "options": {
@@ -8639,8 +8067,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8655,10 +8082,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_schedstat_timeslices_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -8676,7 +8099,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Breaks down hardware interrupts by type and device. Useful for diagnosing IRQ load on network, disk, or CPU interfaces. Requires --collector.interrupts to be enabled in node_exporter",
           "fieldConfig": {
@@ -8736,7 +8159,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 406
+            "y": 706
           },
           "id": 259,
           "options": {
@@ -8744,8 +8167,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8760,10 +8182,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_interrupts_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -8781,7 +8199,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of bits of entropy currently available to the system's random number generators (e.g., /dev/random). Low values may indicate that random number generation could block or degrade performance of cryptographic operations",
           "fieldConfig": {
@@ -8871,7 +8289,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 406
+            "y": 706
           },
           "id": 151,
           "options": {
@@ -8879,8 +8297,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -8895,10 +8312,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_entropy_available_bits{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8909,10 +8322,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_entropy_pool_size_bits{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -8944,7 +8353,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Monitors hardware sensor temperatures and critical thresholds as exposed by Linux hwmon. Includes CPU, GPU, and motherboard sensors where available",
           "fieldConfig": {
@@ -9024,7 +8433,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 607
           },
           "id": 158,
           "options": {
@@ -9032,8 +8441,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9048,10 +8456,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_hwmon_temp_celsius{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9063,10 +8467,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "expr": "node_hwmon_temp_crit_alarm_celsius{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
               "hide": true,
@@ -9077,10 +8477,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_hwmon_temp_crit_celsius{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9092,10 +8488,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "expr": "node_hwmon_temp_crit_hyst_celsius{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
               "hide": true,
@@ -9106,10 +8498,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "expr": "node_hwmon_temp_max_celsius{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
               "hide": true,
@@ -9126,7 +8514,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows how hard each cooling device (fan/throttle) is working relative to its maximum capacity",
           "fieldConfig": {
@@ -9205,7 +8593,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 607
           },
           "id": 300,
           "options": {
@@ -9213,8 +8601,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9229,10 +8616,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "100 * node_cooling_device_cur_state{instance=\"$node\",job=\"$job\"} / node_cooling_device_max_state{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9251,7 +8634,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows the online status of power supplies (e.g., AC, battery). A value of 1-Yes indicates the power supply is active/online",
           "fieldConfig": {
@@ -9314,7 +8697,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 377
+            "y": 617
           },
           "id": 302,
           "options": {
@@ -9322,8 +8705,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9338,10 +8720,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_power_supply_online{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9360,7 +8738,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Displays the current fan speeds (RPM) from hardware sensors via the hwmon interface",
           "fieldConfig": {
@@ -9420,7 +8798,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 377
+            "y": 617
           },
           "id": 325,
           "options": {
@@ -9428,8 +8806,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9444,10 +8821,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_hwmon_fan_rpm{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9459,10 +8832,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_hwmon_fan_min_rpm{instance=\"$node\",job=\"$job\"} * on(chip) group_left(chip_name) node_hwmon_chip_names{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9495,7 +8864,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Current number of systemd units in each operational state, such as active, failed, inactive, or transitioning",
           "fieldConfig": {
@@ -9630,7 +8999,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 4098
           },
           "id": 298,
           "options": {
@@ -9638,8 +9007,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9654,10 +9022,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_units{instance=\"$node\",job=\"$job\",state=\"activating\"}",
               "format": "time_series",
@@ -9669,10 +9033,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_units{instance=\"$node\",job=\"$job\",state=\"active\"}",
               "format": "time_series",
@@ -9684,10 +9044,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_units{instance=\"$node\",job=\"$job\",state=\"deactivating\"}",
               "format": "time_series",
@@ -9699,10 +9055,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_units{instance=\"$node\",job=\"$job\",state=\"failed\"}",
               "format": "time_series",
@@ -9714,10 +9066,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_units{instance=\"$node\",job=\"$job\",state=\"inactive\"}",
               "format": "time_series",
@@ -9735,7 +9083,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Current number of active connections per systemd socket, as reported by the Node Exporter systemd collector",
           "fieldConfig": {
@@ -9795,7 +9143,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 4098
           },
           "id": 331,
           "options": {
@@ -9803,8 +9151,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9819,10 +9166,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_systemd_socket_current_connections{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -9840,7 +9183,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of accepted connections per second for each systemd socket",
           "fieldConfig": {
@@ -9900,7 +9243,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 358
+            "y": 4108
           },
           "id": 297,
           "options": {
@@ -9908,8 +9251,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -9924,10 +9266,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_systemd_socket_accepted_connections_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -9945,7 +9283,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of systemd socket connection refusals per second, typically due to service unavailability or backlog overflow",
           "fieldConfig": {
@@ -10005,7 +9343,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 358
+            "y": 4108
           },
           "id": 332,
           "options": {
@@ -10013,8 +9351,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10029,10 +9366,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_systemd_socket_refused_connections_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -10064,7 +9397,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of I/O operations completed per second for the device (after merges), including both reads and writes",
           "fieldConfig": {
@@ -10159,8 +9492,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10175,10 +9507,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_reads_completed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -10188,10 +9516,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_writes_completed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -10207,7 +9531,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of bytes read from or written to the device per second",
           "fieldConfig": {
@@ -10302,8 +9626,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10318,10 +9641,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_read_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -10332,10 +9651,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "exemplar": false,
               "expr": "irate(node_disk_written_bytes_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
@@ -10354,7 +9669,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Average time for requests issued to the device to be served. This includes the time spent by the requests in queue and the time spent servicing them.",
           "fieldConfig": {
@@ -10449,8 +9764,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10465,10 +9779,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_read_time_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval]) / irate(node_disk_reads_completed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -10480,10 +9790,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_write_time_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval]) / irate(node_disk_writes_completed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -10501,7 +9807,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Average queue length of the requests that were issued to the device",
           "fieldConfig": {
@@ -10585,8 +9891,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10601,10 +9906,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_io_time_weighted_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -10621,7 +9922,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of read and write requests merged per second that were queued to the device",
           "fieldConfig": {
@@ -10716,8 +10017,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10732,10 +10032,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_reads_merged_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -10745,10 +10041,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_writes_merged_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "intervalFactor": 1,
@@ -10764,7 +10056,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Percentage of time the disk spent actively processing I/O operations, including general I/O, discards (TRIM), and write cache flushes",
           "fieldConfig": {
@@ -10848,8 +10140,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -10864,10 +10155,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_io_time_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -10878,10 +10165,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_discard_time_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -10892,10 +10175,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_flush_requests_time_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -10913,7 +10192,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Per-second rate of discard (TRIM) and flush (write cache) operations. Useful for monitoring low-level disk activity on SSDs and advanced storage",
           "fieldConfig": {
@@ -10996,8 +10275,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11012,10 +10290,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_discards_completed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -11026,10 +10300,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_discards_merged_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -11040,10 +10310,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_flush_requests_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -11061,7 +10327,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows how many disk sectors are discarded (TRIMed) per second. Useful for monitoring SSD behavior and storage efficiency",
           "fieldConfig": {
@@ -11144,8 +10410,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11160,10 +10425,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_disk_discarded_sectors_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -11180,7 +10441,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of in-progress I/O requests at the time of sampling (active requests in the disk queue)",
           "fieldConfig": {
@@ -11264,8 +10525,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11280,10 +10540,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_disk_io_now{instance=\"$node\",job=\"$job\"}",
               "interval": "",
@@ -11314,7 +10570,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of file descriptors currently allocated system-wide versus the system limit. Important for detecting descriptor exhaustion risks",
           "fieldConfig": {
@@ -11412,8 +10668,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11428,10 +10683,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filefd_maximum{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -11442,10 +10693,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filefd_allocated{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -11462,7 +10709,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of free file nodes (inodes) available per mounted filesystem. A low count may prevent file creation even if disk space is available",
           "fieldConfig": {
@@ -11530,8 +10777,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11546,10 +10792,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_files_free{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -11567,7 +10809,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Indicates filesystems mounted in read-only mode or reporting device-level I/O errors.",
           "fieldConfig": {
@@ -11636,8 +10878,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11652,10 +10893,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_readonly{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -11666,10 +10903,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_device_error{instance=\"$node\",job=\"$job\",device!~'rootfs',fstype!~'tmpfs'}",
               "format": "time_series",
@@ -11687,7 +10920,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of file nodes (inodes) available per mounted filesystem. Reflects maximum file capacity regardless of disk size",
           "fieldConfig": {
@@ -11755,8 +10988,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11771,10 +11003,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_filesystem_files{instance=\"$node\",job=\"$job\",device!~'rootfs'}",
               "format": "time_series",
@@ -11806,7 +11034,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of network packets received and transmitted per second, by interface.",
           "fieldConfig": {
@@ -11886,8 +11114,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -11903,10 +11130,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_packets_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -11918,10 +11141,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_packets_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -11939,7 +11158,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of packet-level errors for each network interface. Receive errors may indicate physical or driver issues; transmit errors may reflect collisions or hardware faults",
           "fieldConfig": {
@@ -12019,8 +11238,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12036,10 +11254,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_errs_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12050,10 +11264,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_errs_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12070,7 +11280,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of dropped packets per network interface. Receive drops can indicate buffer overflow or driver issues; transmit drops may result from outbound congestion or queuing limits",
           "fieldConfig": {
@@ -12142,7 +11352,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 171
+            "y": 121
           },
           "id": 143,
           "options": {
@@ -12150,8 +11360,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12167,10 +11376,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_drop_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12181,10 +11386,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_drop_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12201,7 +11402,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of compressed network packets received and transmitted per interface. These are common in low-bandwidth or special interfaces like PPP or SLIP",
           "fieldConfig": {
@@ -12273,7 +11474,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 171
+            "y": 121
           },
           "id": 141,
           "options": {
@@ -12281,8 +11482,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12298,10 +11498,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_compressed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12312,10 +11508,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_compressed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12332,7 +11524,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming multicast packets received per network interface. Multicast is used by protocols such as mDNS, SSDP, and some streaming or cluster services",
           "fieldConfig": {
@@ -12404,7 +11596,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 181
+            "y": 131
           },
           "id": 146,
           "options": {
@@ -12412,8 +11604,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12429,10 +11620,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_multicast_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12449,7 +11636,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of received packets that could not be processed due to missing protocol or handler in the kernel. May indicate unsupported traffic or misconfiguration",
           "fieldConfig": {
@@ -12521,7 +11708,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 181
+            "y": 131
           },
           "id": 327,
           "options": {
@@ -12529,8 +11716,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12546,10 +11732,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_nohandler_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12566,7 +11748,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of frame errors on received packets, typically caused by physical layer issues such as bad cables, duplex mismatches, or hardware problems",
           "fieldConfig": {
@@ -12638,7 +11820,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 191
+            "y": 141
           },
           "id": 145,
           "options": {
@@ -12646,8 +11828,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12663,10 +11844,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_frame_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12684,7 +11861,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks FIFO buffer overrun errors on network interfaces. These occur when incoming or outgoing packets are dropped due to queue or buffer overflows, often indicating congestion or hardware limits",
           "fieldConfig": {
@@ -12756,7 +11933,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 191
+            "y": 141
           },
           "id": 144,
           "options": {
@@ -12764,8 +11941,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12781,10 +11957,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_receive_fifo_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12795,10 +11967,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_fifo_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12815,7 +11983,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of packet collisions detected during transmission. Mostly relevant on half-duplex or legacy Ethernet networks",
           "fieldConfig": {
@@ -12887,7 +12055,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 151
           },
           "id": 232,
           "options": {
@@ -12895,8 +12063,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -12912,10 +12079,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_colls_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -12932,7 +12095,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of carrier errors during transmission. These typically indicate physical layer issues like faulty cabling or duplex mismatches",
           "fieldConfig": {
@@ -12991,7 +12154,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 201
+            "y": 151
           },
           "id": 231,
           "options": {
@@ -12999,8 +12162,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13016,10 +12178,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "rate(node_network_transmit_carrier_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -13036,7 +12194,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of ARP entries per interface. Useful for detecting excessive ARP traffic or table growth due to scanning or misconfiguration",
           "fieldConfig": {
@@ -13096,7 +12254,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 211
+            "y": 161
           },
           "id": 230,
           "options": {
@@ -13104,8 +12262,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13120,10 +12277,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_arp_entries{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13140,7 +12293,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Current and maximum connection tracking entries used by Netfilter (nf_conntrack). High usage approaching the limit may cause packet drops or connection issues",
           "fieldConfig": {
@@ -13230,7 +12383,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 211
+            "y": 161
           },
           "id": 61,
           "options": {
@@ -13238,8 +12391,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13254,10 +12406,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_nf_conntrack_entries{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13268,10 +12416,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_nf_conntrack_entries_limit{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13288,7 +12432,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Operational and physical link status of each network interface. Values are Yes for 'up' or link present, and No for 'down' or no carrier.\"",
           "fieldConfig": {
@@ -13347,7 +12491,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 221
+            "y": 171
           },
           "id": 309,
           "options": {
@@ -13355,8 +12499,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13372,10 +12515,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_network_up{operstate=\"up\",instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13387,10 +12526,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_network_carrier{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13405,7 +12540,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Maximum speed of each network interface as reported by the operating system. This is a static hardware capability, not current throughput",
           "fieldConfig": {
@@ -13434,7 +12569,7 @@
             "h": 10,
             "w": 6,
             "x": 12,
-            "y": 221
+            "y": 171
           },
           "id": 280,
           "options": {
@@ -13464,10 +12599,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_network_speed_bytes{instance=\"$node\",job=\"$job\"} * 8",
               "format": "time_series",
@@ -13484,7 +12615,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "MTU (Maximum Transmission Unit) in bytes for each network interface. Affects packet size and transmission efficiency",
           "fieldConfig": {
@@ -13512,7 +12643,7 @@
             "h": 10,
             "w": 6,
             "x": 18,
-            "y": 221
+            "y": 171
           },
           "id": 288,
           "options": {
@@ -13542,10 +12673,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_network_mtu_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13576,7 +12703,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks TCP socket usage and memory per node",
           "fieldConfig": {
@@ -13644,8 +12771,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13661,10 +12787,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_alloc{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13676,10 +12798,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_inuse{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13691,10 +12809,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_orphan{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13706,10 +12820,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_tw{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13727,7 +12837,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of UDP and UDPLite sockets currently in use",
           "fieldConfig": {
@@ -13795,8 +12905,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13812,10 +12921,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_UDPLITE_inuse{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13827,10 +12932,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_UDP_inuse{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13848,7 +12949,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Total number of sockets currently in use across all protocols (TCP, UDP, UNIX, etc.), as reported by /proc/net/sockstat",
           "fieldConfig": {
@@ -13916,8 +13017,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -13933,10 +13033,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_sockets_used{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -13954,7 +13050,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of FRAG and RAW sockets currently in use. RAW sockets are used for custom protocols or tools like ping; FRAG sockets are used internally for IP packet defragmentation",
           "fieldConfig": {
@@ -14022,8 +13118,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14039,10 +13134,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_FRAG_inuse{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14054,10 +13145,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_RAW_inuse{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14075,7 +13162,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "TCP/UDP socket memory usage in kernel (in pages)",
           "fieldConfig": {
@@ -14143,8 +13230,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14160,10 +13246,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_mem{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14175,10 +13257,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_UDP_mem{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14196,7 +13274,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Kernel memory used by TCP, UDP, and IP fragmentation buffers",
           "fieldConfig": {
@@ -14264,8 +13342,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14281,10 +13358,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_TCP_mem_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14296,10 +13369,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_UDP_mem_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -14311,10 +13380,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_sockstat_FRAG_memory{instance=\"$node\",job=\"$job\"}",
               "interval": "",
@@ -14330,7 +13395,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Packets processed and dropped by the softnet network stack per CPU. Drops may indicate CPU saturation or network driver limitations",
           "fieldConfig": {
@@ -14410,8 +13475,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14427,10 +13491,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_softnet_processed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14442,10 +13502,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_softnet_dropped_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14463,7 +13519,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "How often the kernel was unable to process all packets in the softnet queue before time ran out. Frequent squeezes may indicate CPU contention or driver inefficiency",
           "fieldConfig": {
@@ -14534,8 +13590,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14551,10 +13606,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_softnet_times_squeezed_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14572,7 +13623,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks the number of packets processed or dropped by Receive Packet Steering (RPS), a mechanism to distribute packet processing across CPUs",
           "fieldConfig": {
@@ -14659,8 +13710,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14676,10 +13726,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_softnet_received_rps_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14691,10 +13737,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_softnet_flow_limit_count_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14727,7 +13769,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of octets sent and received at the IP layer, as reported by /proc/net/netstat",
           "fieldConfig": {
@@ -14807,8 +13849,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14824,10 +13865,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_IpExt_InOctets{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14839,10 +13876,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_IpExt_OutOctets{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14859,7 +13892,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of TCP segments sent and received per second, including data and control segments",
           "fieldConfig": {
@@ -14950,8 +13983,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -14966,10 +13998,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_InSegs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -14981,10 +14009,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_OutSegs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15002,7 +14026,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of UDP datagrams sent and received per second, based on /proc/net/netstat",
           "fieldConfig": {
@@ -15082,8 +14106,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15098,10 +14121,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_InDatagrams{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15113,10 +14132,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_OutDatagrams{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15134,7 +14149,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of ICMP messages sent and received per second, including error and control messages",
           "fieldConfig": {
@@ -15218,8 +14233,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15234,10 +14248,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Icmp_InMsgs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15249,10 +14259,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Icmp_OutMsgs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15270,7 +14276,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks various TCP error and congestion-related events, including retransmissions, timeouts, dropped connections, and buffer issues",
           "fieldConfig": {
@@ -15338,8 +14344,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15354,10 +14359,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_ListenOverflows{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15370,10 +14371,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_ListenDrops{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15386,10 +14383,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPSynRetrans{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15401,10 +14394,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_RetransSegs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -15413,10 +14402,6 @@
               "refId": "D"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_InErrs{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -15425,10 +14410,6 @@
               "refId": "E"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_OutRsts{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -15437,10 +14418,6 @@
               "refId": "F"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPRcvQDrop{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -15450,10 +14427,6 @@
               "refId": "G"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPOFOQueue{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -15463,10 +14436,6 @@
               "refId": "H"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_TCPTimeouts{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "hide": false,
@@ -15482,7 +14451,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of UDP and UDPLite datagram delivery errors, including missing listeners, buffer overflows, and protocol-specific issues",
           "fieldConfig": {
@@ -15553,8 +14522,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15569,10 +14537,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_InErrors{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15584,10 +14548,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_NoPorts{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15599,10 +14559,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_UdpLite_InErrors{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "interval": "",
@@ -15611,10 +14567,6 @@
               "refId": "C"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_RcvbufErrors{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15626,10 +14578,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Udp_SndbufErrors{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15647,7 +14595,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of incoming ICMP messages that contained protocol-specific errors, such as bad checksums or invalid lengths",
           "fieldConfig": {
@@ -15727,8 +14675,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15743,10 +14690,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Icmp_InErrors{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15764,7 +14707,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of TCP SYN cookies sent, validated, and failed. These are used to protect against SYN flood attacks and manage TCP handshake resources under load",
           "fieldConfig": {
@@ -15847,8 +14790,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -15863,10 +14805,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_SyncookiesFailed{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15879,10 +14817,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_SyncookiesRecv{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15895,10 +14829,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_TcpExt_SyncookiesSent{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -15917,7 +14847,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of currently established TCP connections and the system's max supported limit. On Linux, MaxConn may return -1 to indicate a dynamic/unlimited configuration",
           "fieldConfig": {
@@ -16015,8 +14945,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16031,10 +14960,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_netstat_Tcp_CurrEstab{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16047,10 +14972,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_netstat_Tcp_MaxConn{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16069,7 +14990,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of UDP packets currently queued in the receive (RX) and transmit (TX) buffers. A growing queue may indicate a bottleneck",
           "fieldConfig": {
@@ -16136,8 +15057,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16152,10 +15072,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_udp_queues{instance=\"$node\",job=\"$job\",ip=\"v4\",queue=\"rx\"}",
               "format": "time_series",
@@ -16168,10 +15084,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_udp_queues{instance=\"$node\",job=\"$job\",ip=\"v4\",queue=\"tx\"}",
               "format": "time_series",
@@ -16190,7 +15102,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of TCP connection initiations per second. 'Active' opens are initiated by this host. 'Passive' opens are accepted from incoming connections",
           "fieldConfig": {
@@ -16258,8 +15170,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16274,10 +15185,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_ActiveOpens{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -16289,10 +15196,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(node_netstat_Tcp_PassiveOpens{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -16310,7 +15213,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of TCP sockets in key connection states. Requires the --collector.tcpstat flag on node_exporter",
           "fieldConfig": {
@@ -16379,8 +15282,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16395,10 +15297,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_tcp_connection_states{state=\"established\",instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16410,10 +15308,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_tcp_connection_states{state=\"fin_wait2\",instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16426,10 +15320,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_tcp_connection_states{state=\"listen\",instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16442,10 +15332,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_tcp_connection_states{state=\"time_wait\",instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16458,10 +15344,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_tcp_connection_states{state=\"close_wait\", instance=\"$node\", job=\"$job\"}",
               "format": "time_series",
@@ -16494,7 +15376,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Duration of each individual collector executed during a Node Exporter scrape. Useful for identifying slow or failing collectors",
           "fieldConfig": {
@@ -16565,8 +15447,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16581,10 +15462,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_scrape_collector_duration_seconds{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -16603,7 +15480,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Rate of CPU time used by the process exposing this metric (user + system mode)",
           "fieldConfig": {
@@ -16670,8 +15547,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16686,10 +15562,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "irate(process_cpu_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
               "format": "time_series",
@@ -16707,7 +15579,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Tracks the memory usage of the process exposing this metric (e.g., node_exporter), including current virtual memory and maximum virtual memory limit",
           "fieldConfig": {
@@ -16759,7 +15631,7 @@
                   }
                 ]
               },
-              "unit": "decbytes"
+              "unit": "bytes"
             },
             "overrides": [
               {
@@ -16829,8 +15701,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -16845,10 +15716,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "process_virtual_memory_bytes{instance=\"$node\",job=\"$job\"}",
               "hide": false,
@@ -16860,10 +15727,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "process_virtual_memory_max_bytes{instance=\"$node\",job=\"$job\"}",
               "hide": false,
@@ -16881,7 +15744,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Number of file descriptors used by the exporter process versus its configured limit",
           "fieldConfig": {
@@ -17003,8 +15866,7 @@
               "calcs": [
                 "min",
                 "mean",
-                "max",
-                "lastNotNull"
+                "max"
               ],
               "displayMode": "table",
               "placement": "bottom",
@@ -17019,10 +15881,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "process_max_fds{instance=\"$node\",job=\"$job\"}",
               "interval": "",
@@ -17033,10 +15891,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "process_open_fds{instance=\"$node\",job=\"$job\"}",
               "interval": "",
@@ -17053,7 +15907,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "prometheus"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Shows whether each Node Exporter collector scraped successfully (1 = success, 0 = failure), and whether the textfile collector returned an error.",
           "fieldConfig": {
@@ -17117,10 +15971,6 @@
           "pluginVersion": "11.6.1",
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "node_scrape_collector_success{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -17133,10 +15983,6 @@
               "step": 240
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "prometheus"
-              },
               "editorMode": "code",
               "expr": "1 - node_textfile_scrape_error{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
@@ -17157,7 +16003,6 @@
       "type": "row"
     }
   ],
-  "preload": false,
   "refresh": "1m",
   "schemaVersion": 41,
   "tags": [
@@ -17167,13 +16012,10 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "Prometheus",
-          "value": "prometheus"
-        },
+        "current": {},
         "includeAll": false,
         "label": "Datasource",
-        "name": "datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
@@ -17181,13 +16023,10 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "text": "node-exporter",
-          "value": "node-exporter"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "",
         "includeAll": false,
@@ -17204,13 +16043,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "9b740c954113",
-          "value": "9b740c954113"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(node_uname_info{job=\"$job\"}, nodename)",
         "includeAll": false,
@@ -17227,13 +16063,10 @@
         "type": "query"
       },
       {
-        "current": {
-          "text": "node-exporter:9100",
-          "value": "node-exporter:9100"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(node_uname_info{job=\"$job\", nodename=\"$nodename\"}, instance)",
         "includeAll": false,
@@ -17276,6 +16109,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Node Exporter Full",
-  "uid": "aelbvnw3cwpa8a",
-  "version": 1
+  "uid": "rYdddlPWk",
+  "version": 96,
+  "weekStart": ""
 }


### PR DESCRIPTION
## The Issue

- #<issue number>

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR bumps the node_exporter dashboard version to the latest; available at https://github.com/rfmoz/grafana-dashboards

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
