### PR TITLE
feat: Add Prometheus config reload command

### DIFF
--- a/commands/host/prometheus
+++ b/commands/host/prometheus
@@ -3,8 +3,31 @@
 #ddev-generated
 ## Description: Launch the prometheus website
 ## Usage: prometheus
-## Example: "ddev prometheus"
+## Example: "ddev prometheus", "ddev prometheus -r", "ddev prometheus --reload"
 
 source .ddev/.env
 
-ddev launch :"${PROMETHEUS_HTTPS_PORT:-9090}"
+# Open Prometheus in preferred browser.
+launch () {
+  ddev launch :"${PROMETHEUS_HTTPS_PORT:-9090}"
+}
+
+# Send a request to reload configuration.
+# Assumes `--web.enable-lifecycle` flag is enabled
+# @See https://prometheus.io/docs/prometheus/latest/configuration/configuration/
+reloadConfig() {
+  curl -X POST "${DDEV_PRIMARY_URL}:${PROMETHEUS_HTTPS_PORT:-9090}/-/reload"
+  echo 'config reloaded'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -r | --reload)
+    reloadConfig
+    exit 0;
+    ;;
+  esac
+  shift
+done
+
+launch

--- a/docker-compose.prometheus.yaml
+++ b/docker-compose.prometheus.yaml
@@ -16,3 +16,4 @@ services:
       command:
        - '--config.file=/etc/prometheus/prometheus.yml'
        - '--web.enable-remote-write-receiver'
+       - '--web.enable-lifecycle' # This enables reloading config.

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -211,11 +211,24 @@ teardown() {
 
   prometheus_health_check
 
+  # Check config for `prometheus` scraper
+  run ddev exec curl -g 'prometheus:9090/api/v1/targets'
+  assert_success
+  assert_output --partial '"job":"prometheus"'
+
+  # Remove Prometheus scraper
+  rm '.ddev/prometheus/scrapers/prometheus.yml'
+
   # Confirm Prometheus command successfully reloads configuration
   run ddev prometheus -r
   assert_success
   refute_output --partial 'Lifecycle API is not enabled'
   assert_output --partial 'config reloaded'
+
+  # Check config for `prometheus` scraper
+  run ddev exec curl -g 'prometheus:9090/api/v1/targets'
+  assert_success
+  refute_output --partial '"job":"prometheus"'
 }
 
 @test "Prometheus port is configurable" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -199,6 +199,25 @@ teardown() {
   assert_output --partial '"user":"db"'
 }
 
+@test "Prometheus command reloads configuration" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  prometheus_health_check
+
+  # Confirm Prometheus command successfully reloads configuration
+  run ddev prometheus -r
+  assert_success
+  refute_output --partial 'Lifecycle API is not enabled'
+  assert_output --partial 'config reloaded'
+}
+
 @test "Prometheus port is configurable" {
   set -eu -o pipefail
 


### PR DESCRIPTION
## The Issue

Currently, modifying the Prometheus configuration requires restarting the entire ddev environment or manually restarting the Prometheus container. This can be disruptive and time-consuming, especially during development and testing.

## How This PR Solves The Issue

This pull request adds a `-r` or `--reload` flag to the `ddev prometheus` command. When this flag is used, the command sends a POST request to the Prometheus `/-/reload` endpoint, which triggers a configuration reload. This allows changes to the Prometheus configuration to be applied immediately without restarting the container.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
