### PR TITLE
feat: add Apache-exporter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ Key files include:
 To expose the status page:
 
 ```yml
-# docker-compose.webserver-status.yaml
-services:
-  web:
-    environment:
-      - HTTP_EXPOSE=8079:8080
-      - HTTPS_EXPOSE=8080:8080
+# .ddev/config.webserver.yaml
+web_extra_exposed_ports:
+  - name: webserver
+    container_port: 8080
+    http_port: 8081
+    https_port: 8080
 ```
 
 The included dashboard is extended from [apache-http-mixin](https://github.com/grafana/jsonnet-libs/tree/master/apache-http-mixin).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   - [Grafana Tempo](#grafana-tempo)
   - [Prometheus](#prometheus)
     - [Customize Prometheus](#customize-prometheus)
+    - [Addon: Apache Exporter](#addon-apache-exporter)
     - [Addon: Nginx Exporter](#addon-nginx-exporter)
     - [Addon: MySql Exporter](#addon-mysql-exporter)
     - [Addon: Postgres Exporter](#addon-postgres-exporter)
@@ -185,6 +186,28 @@ However, this Prometheus will try to load `.ddev/prometheus/scrape-*.yml` files.
 
 ```config
 PROMETHEUS_HTTPS_PORT=9090
+```
+
+#### Addon: Apache Exporter
+
+The Apache Exporter uses [lusotycoon/apache-exporter](https://hub.docker.com/r/lusotycoon/apache-exporter) to monitor the apache webs service.
+
+This addon pre-configures the Apache exporter for a DDEV environment.
+
+Key files include:
+
+- `docker-compose.apache-exporter.yaml`: loads Apache exporter image
+- `apache/server-status.conf`: Add '/server-status' endpoint for Apache status page.
+
+To expose the status page:
+
+```yml
+# docker-compose.webserver-status.yaml
+services:
+  web:
+    environment:
+      - HTTP_EXPOSE=8079:8080
+      - HTTPS_EXPOSE=8080:8080
 ```
 
 #### Addon: Nginx Exporter

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ services:
       - HTTPS_EXPOSE=8080:8080
 ```
 
+The included dashboard is extended from [apache-http-mixin](https://github.com/grafana/jsonnet-libs/tree/master/apache-http-mixin).
+
 #### Addon: Nginx Exporter
 
 The Nginx Exporter uses [NGINX Prometheus exporter](https://hub.docker.com/r/nginx/nginx-prometheus-exporter) to monitor NGINX or NGINX Plus using Prometheus.

--- a/apache/server-status.conf
+++ b/apache/server-status.conf
@@ -1,0 +1,17 @@
+# This page exposes Apache server statics at :8080/server-status
+# NOTE: This information is considered sensitive and should NOT be exposed in a production environment.
+# #ddev-generated
+Listen 8080
+
+<VirtualHost *:8080>
+    DocumentRoot /var/www/html
+
+    <Location "/server-status">
+        SetHandler server-status
+        Require all granted
+    </Location>
+
+    # Optional: Logging
+    ErrorLog /var/log/apache2/server-status-error.log
+    CustomLog /var/log/apache2/server-status-access.log combined
+</VirtualHost>

--- a/docker-compose.apache-exporter.yaml
+++ b/docker-compose.apache-exporter.yaml
@@ -1,0 +1,13 @@
+##ddev-generated
+services:
+  apache-exporter:
+    container_name: ddev-${DDEV_SITENAME}-apache-exporter
+    image: lusotycoon/apache-exporter
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: ${DDEV_APPROOT}
+    volumes:
+    - ".:/mnt/ddev_config"
+    - "ddev-global-cache:/mnt/ddev-global-cache"
+    command: "--scrape_uri http://web:8080/server-status/?auto"

--- a/grafana/provisioning/dashboards/apache.json
+++ b/grafana/provisioning/dashboards/apache.json
@@ -1,0 +1,921 @@
+{
+  "help": "#ddev-generated",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": 5,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "apache-http-mixin"
+      ],
+      "targetBlank": false,
+      "title": "Other Apache HTTP dashboards",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus_datasource}"
+          },
+          "expr": "apache_uptime_seconds_total{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 3,
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "titleSize": 2
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus_datasource}"
+          },
+          "exemplar": false,
+          "expr": "apache_info{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ version }}",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Version",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 70,
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineWidth": 0,
+            "spanNulls": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Down"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Up"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "mergeValues": false,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus_datasource}"
+          },
+          "exemplar": true,
+          "expr": "apache_up{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Apache up",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Apache Up / Down",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Bytes sent"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "unit",
+                "value": "Bps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus_datasource}"
+          },
+          "exemplar": false,
+          "expr": "rate(apache_accesses_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Calls",
+          "refId": "A",
+          "step": 240
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus_datasource}"
+          },
+          "exemplar": false,
+          "expr": "rate(apache_sent_kilobytes_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]) * 1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Bytes sent",
+          "refId": "B"
+        }
+      ],
+      "title": "Load",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus_datasource}"
+          },
+          "exemplar": false,
+          "expr": "increase(apache_duration_ms_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])/increase(apache_accesses_total{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Average response time",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Response time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus_datasource}"
+          },
+          "expr": "apache_scoreboard{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ state }}",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Apache scoreboard statuses",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus_datasource}"
+          },
+          "expr": "apache_workers{job=~\"$job\", instance=~\"$instance\"}\n",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{ state }}",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Apache worker statuses",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "${prometheus_datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${prometheus_datasource}"
+          },
+          "expr": "apache_cpuload{job=~\"$job\", instance=~\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Load",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "title": "Apache CPU load",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "tags": [
+    "apache",
+    "prometheus",
+    "web"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "label": "Data source",
+        "name": "prometheus_datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "$prometheus_datasource",
+        "includeAll": true,
+        "label": "job",
+        "multi": true,
+        "name": "job",
+        "options": [],
+        "query": "label_values(apache_up, job)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "apache-exporter:9117",
+          "value": "apache-exporter:9117"
+        },
+        "datasource": "$prometheus_datasource",
+        "includeAll": false,
+        "label": "instance",
+        "name": "instance",
+        "options": [],
+        "query": "label_values(apache_up{job=~\"$job\"}, instance)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "default",
+  "title": "Apache333",
+  "uid": "apache-https",
+  "version": 1
+}

--- a/install.yaml
+++ b/install.yaml
@@ -59,4 +59,20 @@ post_install_actions:
           ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, REPLICA MONITOR ON *.* TO 'db'@'%';"
         fi
     fi
+  - |
+    #ddev-nodisplay
+    #ddev-description:Cleanup unused webserver exporters.
+    echo "$DDEV_WEBSERVER_TYPE ---------------------"
+    if [ "$DDEV_WEBSERVER_TYPE" == "nginx-fpm" ] || [ "$DDEV_WEBSERVER_TYPE" == "generic" ]; then
+        echo "cleaning .... $DDEV_WEBSERVER_TYPE"
+        grep -q '#ddev-generated' docker-compose.apache-exporter.yaml && rm docker-compose.apache-exporter.yaml
+        grep -q '#ddev-generated' grafana/provisioning/dashboards/apache.json && rm grafana/provisioning/dashboards/apache.json
+        grep -q '#ddev-generated' prometheus/scrapers/apache-exporter.yml && rm prometheus/scrapers/apache-exporter.yml
+    fi
+    if [ "$DDEV_WEBSERVER_TYPE" == "apache-fpm" ] || [ "$DDEV_WEBSERVER_TYPE" == "generic" ]; then
+        echo "cleaning .... $DDEV_WEBSERVER_TYPE"
+        grep -q '#ddev-generated' docker-compose.nginx-exporter.yaml && rm docker-compose.nginx-exporter.yaml
+        grep -q '#ddev-generated' grafana/provisioning/dashboards/nginx.json && rm grafana/provisioning/dashboards/nginx.json
+        grep -q '#ddev-generated' prometheus/scrapers/nginx-exporter.yml && rm prometheus/scrapers/nginx-exporter.yml
+    fi
   - ddev dotenv set .ddev/.env --node-exporter-http-port=9100 > /dev/null 2>&1

--- a/install.yaml
+++ b/install.yaml
@@ -17,6 +17,9 @@ project_files:
   # The following files belong to the tempo feature
   - docker-compose.grafana-tempo.yaml
   - tempo/tempo-config.yaml
+  # The following files belong to apache-exporter feature.
+  - docker-compose.apache-exporter.yaml
+  - apache/server-status.conf
   # The following files belong to the nginx-prometheus-exporter feature.
   - docker-compose.nginx-exporter.yaml
   - nginx_full/stub_status.conf

--- a/install.yaml
+++ b/install.yaml
@@ -39,6 +39,7 @@ post_install_actions:
   - docker volume create grafana-storage
   - ddev dotenv set .ddev/.env --prometheus-https-port=9090 > /dev/null 2>&1
   - ddev dotenv set .ddev/.env --grafana-https-port=3000 > /dev/null 2>&1
+  - ddev dotenv set .ddev/.env --node-exporter-http-port=9100 > /dev/null 2>&1
   - |
     #ddev-nodisplay
     #ddev-description:Cleanup unused database exporters.
@@ -75,4 +76,3 @@ post_install_actions:
         grep -q '#ddev-generated' grafana/provisioning/dashboards/nginx.json && rm grafana/provisioning/dashboards/nginx.json
         grep -q '#ddev-generated' prometheus/scrapers/nginx-exporter.yml && rm prometheus/scrapers/nginx-exporter.yml
     fi
-  - ddev dotenv set .ddev/.env --node-exporter-http-port=9100 > /dev/null 2>&1

--- a/prometheus/scrapers/apache-exporter.yml
+++ b/prometheus/scrapers/apache-exporter.yml
@@ -1,0 +1,12 @@
+##ddev-generated
+
+# Apache Exporter
+# This file configures Prometheus for Apache Exporter. Metrics are prefixed with `apache`.
+# @See https://github.com/Lusitaniae/apache_exporter
+
+scrape_configs:
+  # Get exposed Apache metrics
+  - job_name: 'apache-exporter'
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['apache-exporter:9117']

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -83,7 +83,7 @@ grafana_tempo_health_check() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  # [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -224,7 +224,7 @@ teardown() {
 @test "Apache metrics are exposed" {
   set -eu -o pipefail
 
-  echo "# Update the webserver_type to Apache; requires a restart to take effect" >&3
+  echo "# Convert project to Apache" >&3
   ddev config --webserver-type 'apache-fpm'
 
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
@@ -262,6 +262,42 @@ teardown() {
   # Prometheus receives metrics
   run curl -sf "https://${PROJNAME}.ddev.site:9090/api/v1/metadata"
   assert_output --partial "${TARGET_METRIC}"
+}
+
+
+@test "It only installs one webserver type" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Assert 'nginx-exporter' files exist.
+  assert_file_exists .ddev/docker-compose.nginx-exporter.yaml
+  assert_file_exists .ddev/grafana/provisioning/dashboards/nginx.json
+  assert_file_exists .ddev/prometheus/scrapers/nginx-exporter.yml
+
+  # Assert 'apache-exporter' files do NOT exist.
+  assert_file_not_exist .ddev/docker-compose.apache-exporter.yaml
+  assert_file_not_exist .ddev/grafana/provisioning/dashboards/apache.json
+  assert_file_not_exist .ddev/prometheus/scrapers/apache-exporter.yml
+
+  echo "# Convert project to Apache" >&3
+  ddev config --webserver-type='apache-fpm'
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Assert 'nginx-exporter' files do NOT exist.
+  assert_file_not_exist .ddev/docker-compose.nginx-exporter.yaml
+  assert_file_not_exist .ddev/grafana/provisioning/dashboards/nginx.json
+  assert_file_not_exist .ddev/prometheus/scrapers/nginx-exporter.yml
+
+  # Assert 'apache-exporter' files exist.
+  assert_file_exists .ddev/docker-compose.apache-exporter.yaml
+  assert_file_exists .ddev/grafana/provisioning/dashboards/apache.json
+  assert_file_exists .ddev/prometheus/scrapers/apache-exporter.yml
 }
 
 @test "MySQL metrics are exposed for MariaDB" {


### PR DESCRIPTION
## The Issue

This pull request introduces an Apache Exporter addon for ddev, enabling monitoring of Apache web servers using Prometheus and Grafana.

## How This PR Solves The Issue

This pull request intergrate Apache monitoring by:

-   Adding a `/server-status` endpoint to apache to expose statistics.
-   Deploying the `lusotycoon/apache-exporter` Docker image within the ddev environment.
-   Configuring Prometheus to scrape metrics from the Apache exporter.
-   Providing a Grafana dashboard for visualizing the collected metrics.

## Manual Testing Instructions

1.  **Ensure a ddev project is running**

2.  **Switch ddev project to apache-fpm**

    ```bash
    ddev config --webserver-type='apache-fpm'
    ```

3.  **Get the addon:**


    ```bash
    ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/20250619-apache-exporter
    ```

4.  **Restart ddev:**

    ```bash
    ddev restart
    ```


5.  **Access the Prometheus UI:**

   `ddev launch :9090

6.  **Query Apache metrics in Prometheus:**

    In the Prometheus UI, enter the following query:

    ```
    apache_up
    ```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
