### PR TITLE
refactor: remove restart to improve test speed

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -34,8 +34,6 @@ setup() {
   cd "${TESTDIR}"
   run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site
   assert_success
-  run ddev start -y
-  assert_success
 }
 
 health_checks() {


### PR DESCRIPTION
## The Issue

Its taking a whil to run all the automated tests.

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

This PR removes a 'restart' in the test stup function.
This tests that DDEV starts, but we haven't done anything so any problems would be upstream.

This affects all tests so should save a minute or 2.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
