### PR TITLE
feat: Add gRPC endpoint to OTLP receiver and exporter

### DIFF
--- a/alloy/otelcol.alloy
+++ b/alloy/otelcol.alloy
@@ -1,6 +1,9 @@
 // ##ddev-generated
 
 otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint="grafana-alloy:4317"
+  }
   http {
     endpoint="grafana-alloy:4318"
   }
@@ -90,6 +93,20 @@ otelcol.exporter.prometheus "default" {
 
 otelcol.exporter.loki "default" {
   forward_to = [loki.write.default.receiver]
+}
+
+/**
+ * 'otelcol.exporter.otlp' accepts telemetry data from other otelcol components and writes them over the network using the OTLP gRPC protocol.
+ * @See https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlp/
+ */
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "grafana-tempo:4317"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
 }
 
 otelcol.exporter.otlphttp "tempo" {

--- a/tempo/tempo-config.yaml
+++ b/tempo/tempo-config.yaml
@@ -8,7 +8,9 @@ distributor:
     otlp:
       protocols:
         http:
-          endpoint: "grafana-tempo:4318"  # Replace 3200 with your desired port number
+          endpoint: "grafana-tempo:4318"
+        grpc:
+          endpoint: "grafana-tempo:4317"
 
 compactor:
   compaction:


### PR DESCRIPTION
## The Issue

Without explicitly configuring the OTLP gRPC endpoint, the collector and tempo service were not configured to correctly receive and process telemetry data sent over gRPC, potentially leading to data loss or incomplete traces.

## How This PR Solves The Issue

This PR makes the following changes:

*   **`alloy/otelcol.alloy`:**
    *   Added `grpc` block to `otelcol.receiver.otlp "default"` to explicitly set the gRPC endpoint to `grafana-alloy:4317`.
    *   Added `otelcol.exporter.otlp "tempo"` component to export traces to tempo using gRPC protocol

*   **`tempo/tempo-config.yaml`:**
    *   Added `grpc` block under `distributor.otlp.protocols` with the endpoint set to `grafana-tempo:4317`.

These changes ensure that the collector can receive OTLP gRPC data and that tempo is configured to listen for gRPC connections on the correct port.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
