### PR TITLE
refactor: be explicit with scrape metric paths

### DIFF
--- a/prometheus/scrapers/node-exporter.yml
+++ b/prometheus/scrapers/node-exporter.yml
@@ -7,5 +7,6 @@
 scrape_configs:
   # Get exposed Node metrics
   - job_name: 'node-exporter'
+    metrics_path: '/metrics'
     static_configs:
       - targets: ['node-exporter:9100']

--- a/prometheus/scrapers/postgres-exporter.yml
+++ b/prometheus/scrapers/postgres-exporter.yml
@@ -7,5 +7,6 @@
 scrape_configs:
   # Get exposed Postgres metrics
   - job_name: 'postgres'
+    metrics_path: '/metrics'
     static_configs:
       - targets: ['postgres-exporter:9187']

--- a/prometheus/scrapers/prometheus.yml
+++ b/prometheus/scrapers/prometheus.yml
@@ -6,5 +6,6 @@
 scrape_configs:
   # Expose additional metrics
   - job_name: 'prometheus'
+    metrics_path: '/metrics'
     static_configs:
     - targets: ['localhost:9090']


### PR DESCRIPTION
## The Issue

This pull request addresses an issue where the `metrics_path` was not explicitly defined in the scrape configurations.

While this did not seem to affect functionality, explicitly stating the endpoint is considered good practice and helps new developers unfamiliar with the project.

## How This PR Solves The Issue

This pull request addresses an issue where the `metrics_path` was not explicitly defined in the scrape configurations for `node-exporter`, `postgres-exporter`, and `prometheus` jobs in the Prometheus configuration.

**Changes:**

- **prometheus/scrapers/node-exporter.yml:** Added `metrics_path: '/metrics'` to the `node-exporter` job configuration.
- **prometheus/scrapers/postgres-exporter.yml:** Added `metrics_path: '/metrics'` to the `postgres` job configuration.
- **prometheus/scrapers/prometheus.yml:** Added `metrics_path: '/metrics'` to the `prometheus` job configuration.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
