### PR TITLE
docs: update README to display used ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After installation, make sure to commit the .ddev directory to version control.
 | `9090`                       | Prometheus        | ✅           | `PROMETHEUS_HTTPS_PORT`   |
 | `9100`                       | Node Exporter     | ❌           | `NODE_EXPORTER_HTTP_PORT` |
 | `9104`                       | MySQL Exporter    | ❌           |                           |
-| `9133`                       | Nginx Exporter    | ❌           |                           |
+| `9113`                       | Nginx Exporter    | ❌           |                           |
 | `9187`                       | Postgres Exporter | ❌           |                           |
 | `4317` `4318`, `12345`       | Grafana Alloy     | ✅ (`12345`) |                           |
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - [Overview](#overview)
 - [Installation](#installation)
+  - [Ports](#ports)
 - [Tools](#tools)
   - [Grafana](#grafana)
     - [Configure Datasources](#configure-datasources)
@@ -44,6 +45,20 @@ ddev restart
 ```
 
 After installation, make sure to commit the .ddev directory to version control.
+
+### Ports
+
+| Port                         | Service           | UI          | Environment variable      |
+| ---------------------------- | ----------------- | ----------- | ------------------------- |
+| `3000`                       | Grafana           | ✅           | `GRAFANA_HTTPS_PORT`      |
+| `3100`                       | Grafana Loki      | ❌           |                           |
+| `3200`, `3300`,`4317` `4318` | Grafana Tempo     | ❌           |                           |
+| `9090`                       | Prometheus        | ✅           | `PROMETHEUS_HTTPS_PORT`   |
+| `9100`                       | Node Exporter     | ❌           | `NODE_EXPORTER_HTTP_PORT` |
+| `9104`                       | MySQL Exporter    | ❌           |                           |
+| `9133`                       | Nginx Exporter    | ❌           |                           |
+| `9187`                       | Postgres Exporter | ❌           |                           |
+| `4317` `4318`, `12345`       | Grafana Alloy     | ✅ (`12345`) |                           |
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ After installation, make sure to commit the .ddev directory to version control.
 | `9100`                       | Node Exporter     | ❌           | `NODE_EXPORTER_HTTP_PORT` |
 | `9104`                       | MySQL Exporter    | ❌           |                           |
 | `9113`                       | Nginx Exporter    | ❌           |                           |
+| `9117`                       | Apache Exporter   | ❌           |                           |
 | `9187`                       | Postgres Exporter | ❌           |                           |
 | `4317` `4318`, `12345`       | Grafana Alloy     | ✅ (`12345`) |                           |
 

--- a/docker-compose.grafana-loki.yaml
+++ b/docker-compose.grafana-loki.yaml
@@ -14,4 +14,3 @@ services:
     command: '-config.file=/etc/loki/local-config.yaml -config.expand-env=true'
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTPS_EXPOSE=3100:3100

--- a/docker-compose.nginx-exporter.yaml
+++ b/docker-compose.nginx-exporter.yaml
@@ -11,8 +11,7 @@ services:
     - ".:/mnt/ddev_config"
     - "ddev-global-cache:/mnt/ddev-global-cache"
     environment:
-      - HTTP_EXPOSE=9113:9113
-      - HTTPS_EXPOSE=9112:9113
+      - HTTPS_EXPOSE=9113:9113
     command: --nginx.scrape-uri=http://web:8080/stub_status
 
   web:


### PR DESCRIPTION
## The Issue

This projects uses many ports internally, and exposes a few to the host.
While this addon uses the default ports for each service, it can be difficult to keep track of what they are.

## How This PR Solves The Issue

This PR adds a table to the docs lsting ports used.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/doc-ports
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
