### PR TITLE
fix: Grant correct privileges for older MariaDB versions

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -56,8 +56,15 @@ post_install_actions:
         if [[ "$DDEV_DATABASE" == *"mysql"* ]]; then
           ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'db'@'%';"
         fi
-        if [[ "$DDEV_DATABASE" == *"mariadb"* ]]; then
-          ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, REPLICA MONITOR ON *.* TO 'db'@'%';"
+        if [[  $DDEV_DATABASE =~ mariadb:([0-9]+)\.([0-9]+) ]]; then
+          major="${BASH_REMATCH[1]}"
+          minor="${BASH_REMATCH[2]}"
+
+          if (( major > 10 )) || (( major == 10 && minor >= 5 )); then
+            ddev mysql -e "GRANT PROCESS, REPLICATION CLIENT, REPLICA MONITOR ON *.* TO 'db'@'%';"
+          else
+            ddev mysql -e "GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'db'@'%';"
+          fi
         fi
     fi
   - |


### PR DESCRIPTION
## The Issue

The `install.yaml` file was unconditionally granting the `REPLICA MONITOR` privilege to the `db` user when a MariaDB database was detected. This privilege is not available in MariaDB versions older than 10.5.

## How This PR Solves The Issue

This pull request addresses an issue where the wrong privileges were being granted to the `db` user in MariaDB databases older than version 10.5.  Specifically, `REPLICA MONITOR` privilege was being granted, which is only available in MariaDB 10.5 and later.  On older versions this results in errors during the add-on installation and potentially prevents the exporter from functioning correctly.

This PR introduces version checking for MariaDB.  If the MariaDB version is older than 10.5, the script will grant `REPLICATION SLAVE` privilege instead of `REPLICA MONITOR`.

## Manual Testing Instructions

1. Configure a project with MariaDB <= 10.4

```shell
ddev config --database=mariadb:10.4
```

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/fix--support-older-versions-of-MariaDB
ddev restart
```

1. Open Grafana and confirm MariaDB metrics are available.

## Automated Testing Overview

```shell
bats ./tests/test.bats -f 'MySQL metrics are exposed for older MariaDB'
```

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
