### PR TITLE
feat: reload Grafana provisioning

### DIFF
--- a/commands/host/grafana
+++ b/commands/host/grafana
@@ -7,4 +7,29 @@
 
 source .ddev/.env
 
-ddev launch :"${GRAFANA_HTTPS_PORT:-3000}"
+PORT="${GRAFANA_HTTPS_PORT:-3000}"
+
+# Open Grafana in preferred browser.
+launch () {
+  ddev launch :"${PORT}"
+}
+
+# Send a request to reload configuration.
+reloadConfig() {
+  ddev exec curl  -X POST "admin:admin@grafana:${PORT}/api/admin/provisioning/dashboards/reload"
+  ddev exec curl  -X POST "admin:admin@grafana:${PORT}/api/admin/provisioning/datasources/reload"
+  ddev exec curl  -X POST "admin:admin@grafana:${PORT}/api/admin/provisioning/plugins/reload"
+  ddev exec curl  -X POST "admin:admin@grafana:${PORT}/api/admin/provisioning/alerting/reload"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  -r | --reload)
+    reloadConfig
+    exit 0;
+    ;;
+  esac
+  shift
+done
+
+launch

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -114,6 +114,27 @@ teardown() {
   assert_output --partial "<title>Grafana</title>"
 }
 
+@test "Grafana command reloads configuration" {
+  set -eu -o pipefail
+
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  run ddev restart -y
+  assert_success
+
+  grafana_health_check
+
+  # Confirm Grafana command successfully reloads configuration
+  run ddev grafana -r
+  assert_success
+  assert_output --partial 'Dashboards config reloaded'
+  assert_output --partial 'Datasources config reloaded'
+  assert_output --partial 'Plugins config reloaded'
+  assert_output --partial 'Alerting config reloaded'
+}
+
 @test "Grafana settings are persisted" {
   set -eu -o pipefail
 


### PR DESCRIPTION
## The Issue

Currently, when configuration changes are made to Grafana through provisioning files, users must restart the `ddev` environment or manually restart the Grafana container to apply these changes. This process can be time-consuming and disruptive to the development workflow.

Note: Grafana does NOT support reload of basic settings. It recommends restarting the server.

## How This PR Solves The Issue

This pull request adds a `-r` or `--reload` flag to the `ddev grafana` command. When this flag is used, the command sends HTTP POST requests to Grafana's API endpoints for reloading dashboards, data sources, plugins and alerting configuration. This triggers a configuration reload without requiring a full container restart.

## Manual Testing Instructions

1. Install addon

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/feat--reload-Grafana-provisioning
ddev restart
```

2. View list of dashboards at `:3000/dashboards`
3. In `.ddev/grafana/provisioning/dashboards/node.json`, update the `title` field:

```diff
-  "title": "Node Exporter Full",
+  "title": "Foobar",
```

4. Confirm title does NOT update on reload
5. Run `ddev grafana -r` to reload provisioning
6. Confirm title now displays as 'Foobar'

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
