### PR TITLE
Pin Grafana Tempo version

### DIFF
--- a/docker-compose.grafana-tempo.yaml
+++ b/docker-compose.grafana-tempo.yaml
@@ -2,7 +2,7 @@
 services:
   grafana-tempo:
     container_name: ddev-${DDEV_SITENAME}-grafana-tempo
-    image: grafana/tempo:latest
+    image: grafana/tempo:main-298b900
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}

--- a/tempo/tempo-config.yaml
+++ b/tempo/tempo-config.yaml
@@ -12,10 +12,6 @@ distributor:
         grpc:
           endpoint: "grafana-tempo:4317"
 
-compactor:
-  compaction:
-    block_retention: 48h                # configure total trace retention here
-
 ingester:
   trace_idle_period: 10s
   max_block_duration: 1m  # Reduce from 5m to 1m


### PR DESCRIPTION
## The Issue

- No specific issue referenced.

While testing with a project locally, I receieved the following message:

> Failed to restart test-ddev-site-metrics-laravel: container(s) failed to become healthy before their configured timeout or in 120 seconds.


Docker logs revealed:

```shell
$ ddev logs -s grafana-tempo                                  
failed parsing config: failed to parse configFile /etc/tempo/tempo-config.yaml: yaml: unmarshal errors:
  line 15: field compactor not found in type app.Config
```

## How This PR Solves The Issue

This PR pins the tempo version to the latest current version.  Pinning the Grafana Tempo version to a specific commit ensures stability and prevents unexpected changes from the latest version.

In addition, I used AI to find the outdated config and remove it. 


## Manual Testing Instructions

```bash
ddev add-on get https://github.com/tyler36/ddev-site-metrics/tarball/<branch>
ddev restart
```

## Automated Testing Overview

No tests are needed as this change is a version pinning.

## Release/Deployment Notes

Ensure that the deployment uses the specified version of Grafana Tempo to maintain compatibility.

